### PR TITLE
Add turn flow scaffolding with planning and execution phases

### DIFF
--- a/server/bun.lock
+++ b/server/bun.lock
@@ -17,20 +17,26 @@
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.2", "", {}, "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ=="],
+
+    "@types/bun": ["@types/bun@1.2.21", "", { "dependencies": { "bun-types": "1.2.21" } }, "sha512-NiDnvEqmbfQ6dmZ3EeUO577s4P5bf4HCTXtI6trMc6f6RzirY5IrF3aIookuSpyslFzrnvv2lmEWv5HyC1X79A=="],
 
     "@types/delaunator": ["@types/delaunator@5.0.3", "", {}, "sha512-6tTLP8NX0OwtB/fmW9bXp4EWPptawTSsrSGjboWRuzqkxNEEJGyzRPHbr8wnV2DBWfAZ+EPTOvW3B/KysJrl2g=="],
 
-    "@types/node": ["@types/node@22.15.29", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ=="],
+    "@types/node": ["@types/node@24.3.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow=="],
 
-    "bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+    "@types/react": ["@types/react@19.1.12", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w=="],
+
+    "bun-types": ["bun-types@1.2.21", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-sa2Tj77Ijc/NTLS0/Odjq/qngmEPZfbfnOERi0KRUYhT9R8M4VBioWVmMWE5GrYbKMc+5lVybXygLdibHaqVqw=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
 
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "generate-mesh:small": "bun run src/scripts/generate-meshes.ts small",
     "generate-mesh:medium": "bun run src/scripts/generate-meshes.ts medium",
     "generate-mesh:large": "bun run src/scripts/generate-meshes.ts large",
-    "generate-mesh:xl": "bun run src/scripts/generate-meshes.ts xl"
+    "generate-mesh:xl": "bun run src/scripts/generate-meshes.ts xl",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -18,6 +19,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "delaunator": "^5.0.1"
+    "delaunator": "^5.0.1",
+    "@msgpack/msgpack": "^3.1.2"
   }
 }

--- a/server/src/game-actions/handler.ts
+++ b/server/src/game-actions/handler.ts
@@ -5,6 +5,7 @@ import { GameStateManager } from "../game-state";
 import { meshService } from "../mesh-service";
 import type { Entity, Game, GameState } from "../types";
 import { broadcastGameStateUpdate } from "../index";
+import { TurnManager } from "../turn";
 
 export async function handleGameAction(ws: ServerWebSocket<any>, data: any) {
   const { actionType, gameId, playerId, ...actionData } = data;
@@ -315,9 +316,10 @@ export async function handleEndTurnAction(gameId: string, gameState: GameState, 
   
   // Update game state
   gameState.currentPlayer = nextPlayer;
-  
-  // If we've cycled back to the first player, increment turn number
+
+  // If we've cycled back to the first player, resolve the turn and increment
   if (nextPlayerIndex === 0) {
+    TurnManager.advanceTurn(gameState);
     gameState.turnNumber += 1;
   }
   

--- a/server/src/game-state/manager.ts
+++ b/server/src/game-state/manager.ts
@@ -36,7 +36,10 @@ export class GameStateManager {
       status: "waiting",
       currentPlayer: players[0], // First player starts
       turnNumber: 1,
-      
+      phase: "planning",
+      currentPlan: null,
+      nextPlan: null,
+
       // Initialize empty ownership maps
       cellOwnership: {},
       playerCells: Object.fromEntries(players.map(p => [p, []])),

--- a/server/src/turn/index.ts
+++ b/server/src/turn/index.ts
@@ -1,0 +1,2 @@
+export { TurnManager } from './manager';
+

--- a/server/src/turn/manager.ts
+++ b/server/src/turn/manager.ts
@@ -1,0 +1,137 @@
+// server/src/turn/manager.ts
+import type { GameState, TurnPlan } from '../types';
+
+/**
+ * Orchestrates the two-phase turn resolution with a one-turn lag.
+ * Planning Phase: players define budgets, policies, and orders that will apply next turn.
+ * Execution Phase: the previous turn's plan is resolved through the Five Gates sequence.
+ */
+export class TurnManager {
+
+  /**
+   * Advance the game by one turn.
+   * Executes the current plan, shifts the next plan into place, and prepares planning for the following turn.
+   */
+  static advanceTurn(gameState: GameState): void {
+    // Step 1: handle carryover effects from ongoing projects, stock updates, etc.
+    this.carryover(gameState);
+
+    // Step 2: execute last turn's plan through the gates and resolution steps.
+    this.executeCurrentPlan(gameState);
+
+    // Step 3: move the upcoming plan into the active slot and initialize a new planning container.
+    gameState.currentPlan = gameState.nextPlan ?? null;
+    gameState.nextPlan = this.createEmptyPlan();
+    gameState.phase = 'planning';
+  }
+
+  /** Ensure a plan exists for players to modify during the planning phase. */
+  static startPlanning(gameState: GameState): void {
+    gameState.phase = 'planning';
+    if (!gameState.nextPlan) {
+      gameState.nextPlan = this.createEmptyPlan();
+    }
+  }
+
+  /** Submit a plan that will execute on the following turn. */
+  static submitPlan(gameState: GameState, plan: TurnPlan): void {
+    gameState.nextPlan = plan;
+  }
+
+  /**
+   * Run the execution phase for the plan scheduled for this turn.
+   * The plan passes sequentially through the Five Gates before downstream systems resolve.
+   */
+  private static executeCurrentPlan(gameState: GameState): void {
+    gameState.phase = 'execution';
+
+    if (!gameState.currentPlan) {
+      // Early turns may have no plan yet; nothing to execute.
+      return;
+    }
+
+    // Gate 1 — Budget
+    this.budgetGate(gameState);
+
+    // Gate 2A — Inputs
+    this.inputsGate(gameState);
+
+    // Gate 2B — Logistics
+    this.logisticsGate(gameState);
+
+    // Gate 3 — Labor
+    this.laborGate(gameState);
+
+    // Gate 4 — Suitability
+    this.suitabilityGate(gameState);
+
+    // Post-gate resolution steps
+    this.multiplySiteFactors(gameState);
+    this.resolveOutputAndConsumption(gameState);
+    this.resolveTradeAndFX(gameState);
+    this.resolveFinance(gameState);
+    this.resolveDevelopment(gameState);
+    this.cleanup(gameState);
+  }
+
+  // === Turn Flow Steps (placeholders) ===
+
+  private static carryover(_gameState: GameState): void {
+    // TODO: Projects advance, stock and rate updates.
+  }
+
+  private static budgetGate(_gameState: GameState): void {
+    // TODO: Fund slots by suitability using last turn's plan.
+  }
+
+  private static inputsGate(_gameState: GameState): void {
+    // TODO: Apply energy and recipe input caps.
+  }
+
+  private static logisticsGate(_gameState: GameState): void {
+    // TODO: Reserve and consume logistics points.
+  }
+
+  private static laborGate(_gameState: GameState): void {
+    // TODO: Assign labor based on welfare and urbanization.
+  }
+
+  private static suitabilityGate(_gameState: GameState): void {
+    // TODO: Apply suitability modifiers to running slots.
+  }
+
+  private static multiplySiteFactors(_gameState: GameState): void {
+    // TODO: Multiply suitability, tech, and welfare modifiers.
+  }
+
+  private static resolveOutputAndConsumption(_gameState: GameState): void {
+    // TODO: Produce outputs and apply consumption and upkeep costs.
+  }
+
+  private static resolveTradeAndFX(_gameState: GameState): void {
+    // TODO: Handle trade settlements and foreign exchange adjustments.
+  }
+
+  private static resolveFinance(_gameState: GameState): void {
+    // TODO: Run the treasury waterfall and debt mechanics.
+  }
+
+  private static resolveDevelopment(_gameState: GameState): void {
+    // TODO: Roll for development and update urbanization levels.
+  }
+
+  private static cleanup(_gameState: GameState): void {
+    // TODO: Finalize turn, carry shortages, and prepare summary.
+  }
+
+  private static createEmptyPlan(): TurnPlan {
+    return {
+      budgets: {},
+      policies: {},
+      slotPriorities: {},
+      tradeOrders: {},
+      projects: {},
+    };
+  }
+}
+

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -22,6 +22,22 @@ export type ActionType =
   | "research"
   | "recruit";
 
+export type TurnPhase = "planning" | "execution";
+
+export type Gate = "budget" | "inputs" | "logistics" | "labor" | "suitability";
+
+export interface TurnPlan {
+  budgets?: Record<string, any>;
+  policies?: Record<string, any>;
+  slotPriorities?: Record<string, any>;
+  tradeOrders?: Record<string, any>;
+  projects?: Record<string, any>;
+}
+
+export interface TurnSummary {
+  log: string[];
+}
+
 /**
  * Static game metadata that never changes after game creation.
  * This includes basic information about the game session and its participants.
@@ -85,6 +101,15 @@ export interface GameState {
 
   /** Current turn number (increments when all players have taken their turn) */
   turnNumber: number;
+
+  /** Phase of the turn flow (planning or execution) */
+  phase: TurnPhase;
+
+  /** Plan currently being executed */
+  currentPlan: TurnPlan | null;
+
+  /** Plan being prepared for the next turn */
+  nextPlan: TurnPlan | null;
 
   /**
    * Maps each cell to its current owner.


### PR DESCRIPTION
## Summary
- Introduce `TurnManager` to orchestrate planning and execution phases with Five Gate placeholders
- Extend `GameState` and initialization to track current and next plans
- Invoke turn resolution in end-turn action
- Add `test` script and `@msgpack/msgpack` dependency so builds and tests run

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b39977785c8327b1af893c24c5ddf7