### PR TITLE
Scaffold budget system

### DIFF
--- a/server/src/budget/manager.test.ts
+++ b/server/src/budget/manager.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test';
+import { EconomyManager } from '../economy/manager';
+import { BudgetManager, OM_COST_PER_SLOT } from './manager';
+import type { BudgetPools } from '../types';
+
+test('allocates funded slots by suitability with largest remainder', () => {
+  const state = EconomyManager.createInitialState();
+  // create two cantons
+  EconomyManager.addCanton(state, 'A');
+  EconomyManager.addCanton(state, 'B');
+
+  // set capacities and suitability for manufacturing sector
+  state.cantons['A'].sectors.manufacturing = { capacity: 3, funded: 0, idle: 0 };
+  state.cantons['A'].suitability.manufacturing = 0.8;
+  state.cantons['B'].sectors.manufacturing = { capacity: 2, funded: 0, idle: 0 };
+  state.cantons['B'].suitability.manufacturing = 0.5;
+
+  state.resources.gold = 100; // sufficient gold
+  const budget: BudgetPools = {
+    military: 0,
+    welfare: 0,
+    sectorOM: {
+      manufacturing: OM_COST_PER_SLOT.manufacturing * 3,
+    },
+  };
+
+  BudgetManager.applyBudgets(state, budget);
+
+  expect(state.cantons['A'].sectors.manufacturing.funded).toBe(2);
+  expect(state.cantons['B'].sectors.manufacturing.funded).toBe(1);
+});

--- a/server/src/budget/manager.ts
+++ b/server/src/budget/manager.ts
@@ -1,0 +1,177 @@
+// server/src/budget/manager.ts
+import type {
+  EconomyState,
+  SectorType,
+  BudgetPools,
+  RetoolOrder,
+} from '../types';
+
+// Gold cost to operate one slot of each sector for a turn.
+export const OM_COST_PER_SLOT: Record<SectorType, number> = {
+  agriculture: 1,
+  extraction: 1,
+  manufacturing: 1,
+  defense: 1,
+  luxury: 1,
+  finance: 1,
+  research: 1,
+  logistics: 1,
+  energy: 1,
+};
+
+const IDLE_TAX_RATE = 0.25;
+export const RETOOL_COST_PER_SLOT = 8;
+export const RETOOL_TURNS = 2;
+
+/**
+ * Manages budget allocation and slot funding.
+ * Only implements scaffolding and placeholder hooks for other systems.
+ */
+export class BudgetManager {
+  /**
+   * Apply this turn's budget plan to the economy state.
+   * Funds sector O&M slots and charges idle costs.
+   */
+  static applyBudgets(state: EconomyState, budgets: BudgetPools): void {
+    // Military and welfare pools are simply deducted for now.
+    state.resources.gold -= budgets.military;
+    state.resources.gold -= budgets.welfare;
+
+    for (const sector of Object.keys(budgets.sectorOM) as SectorType[]) {
+      const sectorBudget = budgets.sectorOM[sector] ?? 0;
+      this.fundSector(state, sector, sectorBudget);
+    }
+  }
+
+  /**
+   * Fund slots for a single sector across all cantons using suitability
+   * prioritization and largest remainder for fractional allocation.
+   */
+  private static fundSector(state: EconomyState, sector: SectorType, budget: number): void {
+    const costPer = OM_COST_PER_SLOT[sector];
+    if (costPer <= 0) return;
+
+    // Gather capacity and suitability info for cantons that have this sector.
+    const entries: Array<{
+      id: string;
+      capacity: number;
+      suitability: number;
+      funded: number;
+      remainder: number;
+    }> = [];
+
+    for (const [cantonId, canton] of Object.entries(state.cantons)) {
+      const sectorState = canton.sectors[sector];
+      const suitability = canton.suitability[sector] ?? 0;
+      if (!sectorState || sectorState.capacity <= 0) continue;
+      entries.push({
+        id: cantonId,
+        capacity: sectorState.capacity,
+        suitability,
+        funded: 0,
+        remainder: 0,
+      });
+    }
+
+    const totalCapacity = entries.reduce((sum, e) => sum + e.capacity, 0);
+    if (totalCapacity === 0) return;
+
+    const maxFundableSlots = Math.floor(budget / costPer);
+    const slotsToFund = Math.min(maxFundableSlots, totalCapacity);
+
+    // Sort by suitability descending for baseline allocation.
+    entries.sort((a, b) => b.suitability - a.suitability);
+
+    if (slotsToFund >= totalCapacity) {
+      for (const e of entries) {
+        e.funded = e.capacity;
+        this.recordFunding(state, e.id, sector, e.capacity, 0, costPer);
+      }
+      return;
+    }
+
+    // Proportional allocation with largest remainder.
+    for (const e of entries) {
+      const ideal = (e.capacity / totalCapacity) * slotsToFund;
+      e.funded = Math.floor(ideal);
+      e.remainder = ideal - e.funded;
+    }
+
+    let allocated = entries.reduce((sum, e) => sum + e.funded, 0);
+    const remaining = slotsToFund - allocated;
+    if (remaining > 0) {
+      // Distribute remaining slots by remainder, breaking ties by suitability.
+      entries
+        .sort((a, b) => {
+          if (b.remainder === a.remainder) {
+            return b.suitability - a.suitability;
+          }
+          return b.remainder - a.remainder;
+        })
+        .slice(0, remaining)
+        .forEach((e) => {
+          e.funded += 1;
+        });
+    }
+
+    // Record funding and idle costs.
+    for (const e of entries) {
+      const idle = e.capacity - e.funded;
+      this.recordFunding(state, e.id, sector, e.funded, idle, costPer);
+    }
+  }
+
+  private static recordFunding(
+    state: EconomyState,
+    cantonId: string,
+    sector: SectorType,
+    funded: number,
+    idle: number,
+    costPer: number,
+  ): void {
+    const canton = state.cantons[cantonId];
+    const sectorState = canton.sectors[sector];
+    sectorState.funded = funded;
+    sectorState.idle = idle;
+
+    const activeCost = funded * costPer;
+    const idleCost = idle * costPer * IDLE_TAX_RATE;
+    state.resources.gold -= activeCost + idleCost;
+
+    // Hook order for downstream systems.
+    // 1. Non-labor inputs gate (placeholder)
+    // 2. Labor gate (placeholder)
+    // 3. Modifiers & output (placeholder)
+  }
+
+  /** Schedule a retool operation. */
+  static scheduleRetool(state: EconomyState, order: Omit<RetoolOrder, 'turns_remaining'>): void {
+    const canton = state.cantons[order.canton];
+    const fromState = canton.sectors[order.sector_from];
+    if (!fromState || fromState.capacity < order.slots) return;
+
+    fromState.capacity -= order.slots;
+    state.retoolQueue.push({ ...order, turns_remaining: RETOOL_TURNS });
+    state.resources.gold -= order.slots * RETOOL_COST_PER_SLOT;
+  }
+
+  /** Advance retool timers and activate completed slots. */
+  static advanceRetools(state: EconomyState): void {
+    const remaining: RetoolOrder[] = [];
+    for (const order of state.retoolQueue) {
+      order.turns_remaining -= 1;
+      if (order.turns_remaining > 0) {
+        remaining.push(order);
+        continue;
+      }
+      const canton = state.cantons[order.canton];
+      const toState = (canton.sectors[order.sector_to] ||= {
+        capacity: 0,
+        funded: 0,
+        idle: 0,
+      });
+      toState.capacity += order.slots;
+    }
+    state.retoolQueue = remaining;
+  }
+}

--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -66,9 +66,10 @@ export class EconomyManager {
         rareEarths: 0,
         research: 0,
         logistics: 0,
-        labor: 0,
+      labor: 0,
       },
       cantons: {},
+      retoolQueue: [],
     };
   }
 

--- a/server/src/turn/manager.ts
+++ b/server/src/turn/manager.ts
@@ -1,5 +1,6 @@
 // server/src/turn/manager.ts
 import type { GameState, TurnPlan } from '../types';
+import { BudgetManager } from '../budget/manager';
 
 /**
  * Orchestrates the two-phase turn resolution with a one-turn lag.
@@ -78,10 +79,12 @@ export class TurnManager {
 
   private static carryover(_gameState: GameState): void {
     // TODO: Projects advance, stock and rate updates.
+    BudgetManager.advanceRetools(_gameState.economy);
   }
 
   private static budgetGate(_gameState: GameState): void {
-    // TODO: Fund slots by suitability using last turn's plan.
+    if (!_gameState.currentPlan?.budgets) return;
+    BudgetManager.applyBudgets(_gameState.economy, _gameState.currentPlan.budgets);
   }
 
   private static inputsGate(_gameState: GameState): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -26,8 +26,17 @@ export type TurnPhase = "planning" | "execution";
 
 export type Gate = "budget" | "inputs" | "logistics" | "labor" | "suitability";
 
+export interface BudgetPools {
+  /** Gold allocated to military upkeep and discretionary spending */
+  military: number;
+  /** Gold allocated to welfare tiers */
+  welfare: number;
+  /** Operations & Maintenance gold by sector */
+  sectorOM: Partial<Record<SectorType, number>>;
+}
+
 export interface TurnPlan {
-  budgets?: Record<string, any>;
+  budgets?: BudgetPools;
   policies?: Record<string, any>;
   slotPriorities?: Record<string, any>;
   tradeOrders?: Record<string, any>;
@@ -100,16 +109,13 @@ export interface SectorDefinition {
   inputs: ResourceType[];
 }
 
-export interface SectorSlot {
-  id: number;
-  funded: boolean;
-  retooling: number; // turns remaining while retooling; 0 if active
-}
-
 export interface SectorState {
-  capacity: number; // total slots available
-  utilization: number; // slots currently funded and eligible
-  slots: SectorSlot[];
+  /** Total slots available for this sector in the canton */
+  capacity: number;
+  /** Slots funded to attempt running this turn */
+  funded: number;
+  /** Slots idle and charged idle tax */
+  idle: number;
 }
 
 export interface CantonEconomy {
@@ -121,6 +127,16 @@ export interface CantonEconomy {
 export interface EconomyState {
   resources: Resources;
   cantons: { [cantonId: string]: CantonEconomy };
+  /** Slots undergoing retooling and their timers */
+  retoolQueue: RetoolOrder[];
+}
+
+export interface RetoolOrder {
+  canton: string;
+  sector_from: SectorType;
+  sector_to: SectorType;
+  slots: number;
+  turns_remaining: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add budget management scaffolding with military, welfare, and per-sector O&M pools
- Allocate sector slots by suitability and largest remainder; apply idle slot tax
- Introduce retool queue with cost and timing hooks and integrate into turn flow

## Testing
- `cd server && bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b02877888327b18fb9af5c2b2453