### PR TITLE
Add energy system scaffolding with plant types and brownouts

### DIFF
--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -66,10 +66,17 @@ export class EconomyManager {
         rareEarths: 0,
         research: 0,
         logistics: 0,
-      labor: 0,
+        labor: 0,
       },
       cantons: {},
       retoolQueue: [],
+      energy: {
+        plants: [],
+        state: { supply: 0, demand: 0, ratio: 1 },
+        demandBySector: {},
+        brownouts: [],
+        essentialsFirst: false,
+      },
     };
   }
 

--- a/server/src/energy/manager.test.ts
+++ b/server/src/energy/manager.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from 'bun:test';
+import { EconomyManager } from '../economy/manager';
+import { EnergyManager, PLANT_ATTRIBUTES, RENEWABLE_CAPACITY_FACTOR, ENERGY_PER_SLOT } from './manager';
+import type { EconomyState } from '../types';
+
+function basicState(): EconomyState {
+  const state = EconomyManager.createInitialState();
+  EconomyManager.addCanton(state, 'A');
+  return state;
+}
+
+test('all plant types have attributes', () => {
+  expect(Object.keys(PLANT_ATTRIBUTES).sort()).toEqual([
+    'coal',
+    'gas',
+    'hydro',
+    'nuclear',
+    'oilPeaker',
+    'solar',
+    'wind',
+  ]);
+});
+
+test('renewables use capacity factor', () => {
+  const state = basicState();
+  state.energy.plants.push({ canton: 'A', type: 'wind', status: 'active' });
+  EnergyManager.run(state);
+  expect(state.energy.state.supply).toBeCloseTo(
+    PLANT_ATTRIBUTES.wind.baseOutput * RENEWABLE_CAPACITY_FACTOR,
+  );
+});
+
+test('per-sector energy demand tracked and summed', () => {
+  const state = basicState();
+  state.cantons['A'].sectors.agriculture = { capacity: 2, funded: 2, idle: 0 };
+  state.cantons['A'].sectors.finance = { capacity: 2, funded: 0, idle: 2 };
+  state.energy.plants.push({ canton: 'A', type: 'coal', status: 'active' });
+  EnergyManager.run(state);
+  expect(state.energy.demandBySector.agriculture).toBe(
+    2 * ENERGY_PER_SLOT.agriculture,
+  );
+  expect(state.energy.state.demand).toBe(state.energy.demandBySector.agriculture);
+});
+
+test('energy ratio scales utilization and records brownouts', () => {
+  const state = basicState();
+  state.cantons['A'].sectors.agriculture = { capacity: 2, funded: 2, idle: 0 };
+  // no plants => supply 0
+  EnergyManager.run(state);
+  expect(state.energy.state.ratio).toBe(0);
+  expect(state.cantons['A'].sectors.agriculture.funded).toBe(0);
+  expect(state.energy.brownouts.length).toBeGreaterThan(0);
+});
+
+test('essentials first prioritizes specified sectors', () => {
+  const state = basicState();
+  state.cantons['A'].sectors.agriculture = { capacity: 6, funded: 6, idle: 0 };
+  state.cantons['A'].sectors.manufacturing = { capacity: 6, funded: 6, idle: 0 };
+  state.energy.plants.push({ canton: 'A', type: 'coal', status: 'active' });
+  // uniform scaling
+  EnergyManager.run(state);
+  const uniformAg = state.cantons['A'].sectors.agriculture.funded;
+  const uniformMan = state.cantons['A'].sectors.manufacturing.funded;
+  // reset
+  const state2 = basicState();
+  state2.cantons['A'].sectors.agriculture = { capacity: 6, funded: 6, idle: 0 };
+  state2.cantons['A'].sectors.manufacturing = { capacity: 6, funded: 6, idle: 0 };
+  state2.energy.plants.push({ canton: 'A', type: 'coal', status: 'active' });
+  EnergyManager.run(state2, { essentialsFirst: true });
+  expect(state2.cantons['A'].sectors.agriculture.funded).toBeGreaterThan(
+    state2.cantons['A'].sectors.manufacturing.funded,
+  );
+  expect(uniformAg).toBe(uniformMan);
+});
+
+test('idle plants and building plants produce no energy', () => {
+  const state = basicState();
+  state.energy.plants.push({ canton: 'A', type: 'coal', status: 'idle' });
+  state.energy.plants.push({
+    canton: 'A',
+    type: 'solar',
+    status: 'building',
+    turns_remaining: 2,
+  });
+  EnergyManager.run(state);
+  expect(state.energy.state.supply).toBe(0);
+});
+
+test('idle slots do not consume energy', () => {
+  const state = basicState();
+  state.cantons['A'].sectors.agriculture = { capacity: 3, funded: 1, idle: 2 };
+  EnergyManager.run(state);
+  expect(state.energy.state.demand).toBe(1 * ENERGY_PER_SLOT.agriculture);
+});
+

--- a/server/src/energy/manager.ts
+++ b/server/src/energy/manager.ts
@@ -1,0 +1,138 @@
+// server/src/energy/manager.ts
+import type {
+  EconomyState,
+  SectorType,
+  PlantRegistryEntry,
+  PlantType,
+  PlantAttributes,
+} from '../types';
+
+// === Plant Definitions ===
+export const PLANT_ATTRIBUTES: Record<PlantType, PlantAttributes> = {
+  coal: { fuelType: 'coal', baseOutput: 10, oAndMCost: 1, rcf: false },
+  gas: { fuelType: 'oil', baseOutput: 10, oAndMCost: 1, rcf: false },
+  oilPeaker: { fuelType: 'oil', baseOutput: 5, oAndMCost: 1, rcf: false },
+  nuclear: { fuelType: 'uranium', baseOutput: 20, oAndMCost: 2, rcf: false },
+  hydro: { fuelType: null, baseOutput: 8, oAndMCost: 1, rcf: false },
+  wind: { fuelType: null, baseOutput: 6, oAndMCost: 1, rcf: true },
+  solar: { fuelType: null, baseOutput: 5, oAndMCost: 1, rcf: true },
+};
+
+/** Renewable capacity factor applied to wind and solar generation. */
+export const RENEWABLE_CAPACITY_FACTOR = 0.6;
+
+// === Per-sector energy demand (stub values) ===
+export const ENERGY_PER_SLOT: Record<SectorType, number> = {
+  agriculture: 1,
+  extraction: 1,
+  manufacturing: 2,
+  defense: 2,
+  luxury: 1,
+  finance: 0,
+  research: 1,
+  logistics: 1,
+  energy: 0,
+};
+
+export interface EnergyContext {
+  essentialsFirst?: boolean;
+  priorityList?: SectorType[];
+}
+
+function sum(obj: Record<string, number>): number {
+  return Object.values(obj).reduce((s, n) => s + n, 0);
+}
+
+/**
+ * Scaffolding energy manager handling supply, demand and brownouts.
+ */
+export class EnergyManager {
+  static run(state: EconomyState, ctx: EnergyContext = {}): void {
+    const plants = state.energy.plants as PlantRegistryEntry[];
+    let supply = 0;
+    for (const plant of plants) {
+      if (plant.status !== 'active') continue;
+      const attrs = PLANT_ATTRIBUTES[plant.type];
+      if (!attrs) continue;
+      const output = attrs.baseOutput * (attrs.rcf ? RENEWABLE_CAPACITY_FACTOR : 1);
+      supply += output;
+    }
+
+    const demandBySector: Partial<Record<SectorType, number>> = {};
+    for (const canton of Object.values(state.cantons)) {
+      for (const [sectorKey, secState] of Object.entries(canton.sectors) as [
+        SectorType,
+        any,
+      ][]) {
+        if (!secState || secState.funded <= 0) continue;
+        const costPer = ENERGY_PER_SLOT[sectorKey] ?? 0;
+        if (costPer <= 0) continue;
+        demandBySector[sectorKey] =
+          (demandBySector[sectorKey] ?? 0) + secState.funded * costPer;
+      }
+    }
+
+    const totalDemand = sum(demandBySector as Record<string, number>);
+    const ratioOverall = totalDemand > 0 ? Math.min(1, supply / totalDemand) : 1;
+
+    state.energy.state = { supply, demand: totalDemand, ratio: ratioOverall };
+    state.energy.demandBySector = demandBySector;
+    state.energy.brownouts = [];
+
+    if (totalDemand <= supply) return; // no brownouts
+
+    const sectorRatios: Partial<Record<SectorType, number>> = {};
+    if (ctx.essentialsFirst) {
+      const priorities = ctx.priorityList ?? [
+        'agriculture',
+        'defense',
+        'manufacturing',
+      ];
+      let remainingSupply = supply;
+      const prioritized = new Set(priorities);
+      for (const sector of priorities) {
+        const d = demandBySector[sector] ?? 0;
+        const alloc = Math.min(remainingSupply, d);
+        sectorRatios[sector] = d > 0 ? alloc / d : 1;
+        remainingSupply -= alloc;
+      }
+      const otherSectors = (Object.keys(demandBySector) as SectorType[]).filter(
+        (s) => !prioritized.has(s),
+      );
+      const remainingDemand = otherSectors.reduce(
+        (s, sec) => s + (demandBySector[sec] ?? 0),
+        0,
+      );
+      const ratioOthers =
+        remainingDemand > 0 ? Math.min(1, remainingSupply / remainingDemand) : 1;
+      for (const sec of otherSectors) {
+        sectorRatios[sec] = ratioOthers;
+      }
+    } else {
+      for (const sec of Object.keys(demandBySector) as SectorType[]) {
+        sectorRatios[sec] = ratioOverall;
+      }
+    }
+
+    for (const [cantonId, canton] of Object.entries(state.cantons)) {
+      for (const [sectorKey, secState] of Object.entries(canton.sectors) as [
+        SectorType,
+        any,
+      ][]) {
+        if (!secState || secState.funded <= 0) continue;
+        const ratio = sectorRatios[sectorKey];
+        if (ratio === undefined || ratio >= 1) continue;
+        const before = secState.funded;
+        const after = Math.floor(before * ratio);
+        secState.funded = after;
+        state.energy.brownouts.push({
+          canton: cantonId,
+          sector: sectorKey,
+          before,
+          after,
+        });
+      }
+    }
+  }
+}
+

--- a/server/src/turn/manager.ts
+++ b/server/src/turn/manager.ts
@@ -3,6 +3,7 @@ import type { GameState, TurnPlan } from '../types';
 import { BudgetManager } from '../budget/manager';
 import { LaborManager } from '../labor/manager';
 import { LogisticsManager } from '../logistics/manager';
+import { EnergyManager } from '../energy/manager';
 
 /**
  * Orchestrates the two-phase turn resolution with a one-turn lag.
@@ -59,6 +60,9 @@ export class TurnManager {
     // Gate 2A — Inputs
     this.inputsGate(gameState);
 
+    // Gate 2B — Energy
+    this.energyGate(gameState);
+
     // Gate 2B — Logistics
     this.logisticsGate(gameState);
 
@@ -91,6 +95,12 @@ export class TurnManager {
 
   private static inputsGate(_gameState: GameState): void {
     // TODO: Apply energy and recipe input caps.
+  }
+
+  private static energyGate(gameState: GameState): void {
+    EnergyManager.run(gameState.economy, {
+      essentialsFirst: gameState.economy.energy.essentialsFirst,
+    });
   }
 
   private static logisticsGate(_gameState: GameState): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -118,6 +118,46 @@ export interface SectorState {
   idle: number;
 }
 
+// === Energy System Types ===
+
+export type PlantType =
+  | 'coal'
+  | 'gas'
+  | 'oilPeaker'
+  | 'nuclear'
+  | 'hydro'
+  | 'wind'
+  | 'solar';
+
+export type PlantStatus = 'active' | 'idle' | 'building';
+
+export interface PlantRegistryEntry {
+  canton: string;
+  type: PlantType;
+  status: PlantStatus;
+  turns_remaining?: number;
+}
+
+export interface PlantAttributes {
+  fuelType: ResourceType | null;
+  baseOutput: number;
+  oAndMCost: number;
+  rcf: boolean;
+}
+
+export interface EnergyComputation {
+  supply: number;
+  demand: number;
+  ratio: number;
+}
+
+export interface BrownoutRecord {
+  canton: string;
+  sector: SectorType;
+  before: number;
+  after: number;
+}
+
 export interface LaborConsumption {
   foodRequired: number;
   foodProvided: number;
@@ -147,6 +187,14 @@ export interface EconomyState {
   cantons: { [cantonId: string]: CantonEconomy };
   /** Slots undergoing retooling and their timers */
   retoolQueue: RetoolOrder[];
+  /** Energy system tracking */
+  energy: {
+    plants: PlantRegistryEntry[];
+    state: EnergyComputation;
+    demandBySector: Partial<Record<SectorType, number>>;
+    brownouts: BrownoutRecord[];
+    essentialsFirst: boolean;
+  };
 }
 
 export interface RetoolOrder {

--- a/tests/README.md
+++ b/tests/README.md
@@ -64,3 +64,13 @@ This prints coverage statistics and writes an `lcov.info` report to the `coverag
 - Shipments exceeding same-turn thresholds queue to the next turn.
 - LP accounting distinguishes operating, domestic, and international demand components.
 
+### Energy System
+- Plant registry supports Coal, Gas, Oil Peaker, Nuclear, Hydro, Wind, and Solar types.
+- Wind and Solar generation scaled by a Renewable Capacity Factor.
+- Per-sector energy demand is tracked and summed into total demand.
+- Energy supply vs demand produces a ratio used to scale sector utilisation.
+- Brownouts are logged when supply is insufficient.
+- "Essentials First" prioritises Agriculture, Defense, and Manufacturing before other sectors.
+- Plants that are idle or under construction produce no energy.
+- Idle economic slots consume no energy.
+


### PR DESCRIPTION
## Summary
- scaffold an Energy system with plant types, renewable capacity factor, and per-sector energy costs
- track energy supply, demand, shortages, and optional Essentials First prioritization
- integrate energy gate into turn flow and document new pass criteria

## Testing
- `cd server && bun test`
- `cd server && bun run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b3c7725dd48327a8effa6efff5a01d