### PR TITLE
Add Suitability system scaffolding with modifiers and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,23 @@ The automated tests verify the following pass criteria:
 8. Essentials First allocates LP by priority (Agriculture → Defense → Manufacturing → Research → Luxury → Extraction → Finance)
 9. Shipments exceeding same-turn thresholds queue to the next turn
 10. LP accounting distinguishes operating, domestic, and international demand components
+
+## Suitability System Scaffold
+
+This update introduces the Suitability system scaffolding that rates how well a canton supports each economic sector.
+
+- Geography and Urbanization modifier tables are injectable and cached per canton.
+- Scores are rounded, clamped to the range [-60%, +50%], and converted to final multipliers.
+- Suitability runs after the Labor gate as the last multiplier in the Five Gates sequence.
+
+The automated tests verify the following pass criteria:
+
+1. Suitability is produced for every canton–sector pair with both a percent and multiplier.
+2. Geography shares are respected and the weighted sum over tile types is used.
+3. Urbanization Level modifiers are added once based on the canton’s UL.
+4. Rounding to the nearest whole percent occurs before clamping.
+5. Clamping enforces the range [-60%, +50%].
+6. The multiplier equals `1 + (percent/100)` and matches the clamped percent.
+7. Suitability is applied only after the Labor gate and before output tallies.
+8. Changing UL or tile shares changes the computed suitability while unchanged inputs yield identical results across turns.
+9. Cached suitability invalidates when UL or tile shares change and remains stable otherwise.

--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -96,7 +96,9 @@ export class EconomyManager {
       },
       shortages: { food: false, luxury: false },
       urbanizationLevel: 1,
+      geography: { plains: 1 },
       suitability: {},
+      suitabilityMultipliers: {},
     };
   }
 

--- a/server/src/suitability/index.ts
+++ b/server/src/suitability/index.ts
@@ -1,0 +1,1 @@
+export * from './manager';

--- a/server/src/suitability/manager.test.ts
+++ b/server/src/suitability/manager.test.ts
@@ -1,0 +1,126 @@
+import { expect, test } from 'bun:test';
+import { EconomyManager } from '../economy';
+import { SuitabilityManager } from './manager';
+import type { EconomyState, GeographyModifiers, UrbanizationModifiers, SectorType } from '../types';
+
+function setupEconomy(): EconomyState {
+  const state = EconomyManager.createInitialState();
+  EconomyManager.addCanton(state, 'c1');
+  return state;
+}
+
+const allSectors: SectorType[] = [
+  'agriculture',
+  'extraction',
+  'manufacturing',
+  'defense',
+  'luxury',
+  'finance',
+  'research',
+  'logistics',
+];
+
+function configureModifiers() {
+  const geo: GeographyModifiers = {
+    agriculture: { plains: 20, mountains: -10 },
+    manufacturing: { plains: 15, mountains: -30 },
+    // defaults for other sectors will be zero
+  };
+  const ul: UrbanizationModifiers = {
+    agriculture: { 2: 5, 3: 10 },
+    manufacturing: { 2: 3, 3: 6 },
+  };
+  SuitabilityManager.setGeographyModifiers(geo);
+  SuitabilityManager.setUrbanizationModifiers(ul);
+}
+
+// 1. Suitability output structure
+
+test('produces percent and multiplier for each sector', () => {
+  const state = setupEconomy();
+  configureModifiers();
+  const results = SuitabilityManager.run(state);
+  for (const sector of allSectors) {
+    const res = results.c1[sector];
+    expect(typeof res.percent).toBe('number');
+    expect(typeof res.multiplier).toBe('number');
+    expect(state.cantons.c1.suitability[sector]).toBe(res.percent);
+    expect(state.cantons.c1.suitabilityMultipliers[sector]).toBe(res.multiplier);
+  }
+});
+
+// 2. Weighted geography and UL modifier
+
+test('geography shares and UL modifier contribute correctly', () => {
+  const state = setupEconomy();
+  configureModifiers();
+  state.cantons.c1.geography = { plains: 0.6, mountains: 0.4 };
+  state.cantons.c1.urbanizationLevel = 2;
+  const res = SuitabilityManager.run(state).c1.agriculture;
+  // 0.6*20 + 0.4*-10 = 8, + UL(5) = 13 -> rounded 13
+  expect(res.percent).toBe(13);
+  expect(res.multiplier).toBeCloseTo(1.13);
+});
+
+// 3. UL modifier applied once
+
+test('changing UL changes suitability once', () => {
+  const state = setupEconomy();
+  configureModifiers();
+  state.cantons.c1.geography = { plains: 1 };
+  state.cantons.c1.urbanizationLevel = 2;
+  const res2 = SuitabilityManager.run(state).c1.agriculture.percent;
+  state.cantons.c1.urbanizationLevel = 3;
+  const res3 = SuitabilityManager.run(state).c1.agriculture.percent;
+  expect(res3 - res2).toBe(5); // difference between UL modifiers 10-5
+});
+
+// 4. Rounding before clamping
+
+test('rounding occurs before clamping', () => {
+  const state = setupEconomy();
+  configureModifiers();
+  state.cantons.c1.geography = { plains: 1 };
+  state.cantons.c1.urbanizationLevel = 3; // geo 20 + ul 10 = 30
+  // adjust geo modifier to produce 50.6 total: use temporary modifiers
+  SuitabilityManager.setGeographyModifiers({ agriculture: { plains: 40.6 } });
+  SuitabilityManager.setUrbanizationModifiers({ agriculture: { 1: 10 } });
+  state.cantons.c1.urbanizationLevel = 1;
+  const res = SuitabilityManager.run(state).c1.agriculture;
+  expect(res.percent).toBe(50); // 40.6 + 10 = 50.6 -> round 51 -> clamp 50
+  expect(res.multiplier).toBe(1.5);
+});
+
+// 5. Clamping range
+
+test('clamps to [-60,50]', () => {
+  const state = setupEconomy();
+  SuitabilityManager.setGeographyModifiers({ agriculture: { plains: 200 }, manufacturing: { plains: -200 } });
+  SuitabilityManager.setUrbanizationModifiers({});
+  state.cantons.c1.geography = { plains: 1 };
+  const resHigh = SuitabilityManager.run(state).c1.agriculture;
+  expect(resHigh.percent).toBe(50);
+  expect(resHigh.multiplier).toBe(1.5);
+  const resLow = SuitabilityManager.run(state).c1.manufacturing;
+  expect(resLow.percent).toBe(-60);
+  expect(resLow.multiplier).toBe(0.4);
+});
+
+// 6. Cache stability and invalidation
+
+test('cache stable until UL or geography changes', () => {
+  const state = setupEconomy();
+  SuitabilityManager.setGeographyModifiers({ agriculture: { plains: 10 } });
+  SuitabilityManager.setUrbanizationModifiers({ agriculture: { 1: 0 } });
+  const r1 = SuitabilityManager.run(state).c1.agriculture;
+  const r2 = SuitabilityManager.run(state).c1.agriculture;
+  // same object reference when cached
+  expect(r2).toBe(r1);
+  state.cantons.c1.urbanizationLevel = 2;
+  const r3 = SuitabilityManager.run(state).c1.agriculture;
+  expect(r3).not.toBe(r1);
+  state.cantons.c1.urbanizationLevel = 2;
+  state.cantons.c1.geography = { plains: 0.5, mountains: 0.5 };
+  const r4 = SuitabilityManager.run(state).c1.agriculture;
+  expect(r4).not.toBe(r3);
+});

--- a/server/src/suitability/manager.ts
+++ b/server/src/suitability/manager.ts
@@ -1,0 +1,106 @@
+import type {
+  CantonEconomy,
+  EconomyState,
+  GeographyModifiers,
+  SectorType,
+  SuitabilityResult,
+  TileType,
+  UrbanizationModifiers,
+} from '../types';
+
+// Sectors that use suitability (energy handled elsewhere)
+const SUITABILITY_SECTORS: SectorType[] = [
+  'agriculture',
+  'extraction',
+  'manufacturing',
+  'defense',
+  'luxury',
+  'finance',
+  'research',
+  'logistics',
+];
+
+/** Utility to encode tile shares for cache key */
+function encodeShares(geo: Record<TileType, number>): string {
+  return Object.entries(geo)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}:${v}`)
+    .join('|');
+}
+
+export class SuitabilityManager {
+  private static geoModifiers: GeographyModifiers = {};
+  private static ulModifiers: UrbanizationModifiers = {};
+
+  // cache per canton: last UL, tile hash, results
+  private static cache: Record<
+    string,
+    { ul: number; hash: string; results: Record<SectorType, SuitabilityResult> }
+  > = {};
+
+  /** Allow external injection of geography modifiers */
+  static setGeographyModifiers(mods: GeographyModifiers): void {
+    this.geoModifiers = mods;
+    // invalidate cache entirely
+    this.cache = {};
+  }
+
+  /** Allow external injection of urbanization level modifiers */
+  static setUrbanizationModifiers(mods: UrbanizationModifiers): void {
+    this.ulModifiers = mods;
+    this.cache = {};
+  }
+
+  /** Retrieve suitability result for canton-sector pair from cache */
+  static get(cantonId: string, sector: SectorType): SuitabilityResult | undefined {
+    return this.cache[cantonId]?.results[sector];
+  }
+
+  /** Compute suitability for all cantons and sectors. */
+  static run(economy: EconomyState): Record<string, Record<SectorType, SuitabilityResult>> {
+    const output: Record<string, Record<SectorType, SuitabilityResult>> = {};
+
+    for (const [cantonId, canton] of Object.entries(economy.cantons)) {
+      const hash = encodeShares(canton.geography);
+      const ul = canton.urbanizationLevel;
+      let cached = this.cache[cantonId];
+      if (cached && cached.hash === hash && cached.ul === ul) {
+        output[cantonId] = cached.results;
+      } else {
+        const results: Record<SectorType, SuitabilityResult> = {} as any;
+        for (const sector of SUITABILITY_SECTORS) {
+          results[sector] = this.computeSector(canton, sector);
+        }
+        cached = { ul, hash, results };
+        this.cache[cantonId] = cached;
+        output[cantonId] = results;
+      }
+
+      // update canton caches for percent and multiplier
+      for (const sector of SUITABILITY_SECTORS) {
+        const res = cached.results[sector];
+        canton.suitability[sector] = res.percent;
+        canton.suitabilityMultipliers[sector] = res.multiplier;
+      }
+    }
+
+    return output;
+  }
+
+  private static computeSector(canton: CantonEconomy, sector: SectorType): SuitabilityResult {
+    const geoMods = this.geoModifiers[sector] || {};
+    let tfpRaw = 0;
+    for (const [tile, share] of Object.entries(canton.geography) as [TileType, number][]) {
+      const mod = geoMods[tile] ?? 0;
+      tfpRaw += share * mod;
+    }
+    const ulMod = this.ulModifiers[sector]?.[canton.urbanizationLevel] ?? 0;
+    const combined = tfpRaw + ulMod;
+    // round to nearest whole percent
+    const rounded = Math.round(combined);
+    // clamp
+    const clamped = Math.min(Math.max(rounded, -60), 50);
+    const multiplier = 1 + clamped / 100;
+    return { percent: clamped, multiplier };
+  }
+}

--- a/server/src/suitability/turn-hook.test.ts
+++ b/server/src/suitability/turn-hook.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test';
+import { TurnManager } from '../turn/manager';
+import { EconomyManager } from '../economy';
+import { LaborManager } from '../labor/manager';
+import { SuitabilityManager } from './manager';
+import type { GameState, TurnPlan } from '../types';
+
+function createGameState(plan: TurnPlan | null): GameState {
+  return {
+    status: 'in_progress',
+    currentPlayer: 'P1',
+    turnNumber: 1,
+    phase: 'planning',
+    currentPlan: plan,
+    nextPlan: null,
+    cellOwnership: {},
+    playerCells: {},
+    entities: {},
+    cellEntities: {},
+    playerEntities: {},
+    entitiesByType: { unit: [] },
+    economy: EconomyManager.createInitialState(),
+    nextEntityId: 1,
+  } as GameState;
+}
+
+test('suitability gate runs after labor gate', () => {
+  const plan: TurnPlan = { budgets: { military: 0, welfare: 0, sectorOM: {} } };
+  const state = createGameState(plan);
+  const order: string[] = [];
+  const laborOriginal = LaborManager.run;
+  const suitOriginal = SuitabilityManager.run;
+  LaborManager.run = ((econ: any, plan?: any) => {
+    order.push('labor');
+    return laborOriginal.call(LaborManager, econ, plan);
+  }) as any;
+  SuitabilityManager.run = ((econ: any) => {
+    order.push('suit');
+    return suitOriginal.call(SuitabilityManager, econ);
+  }) as any;
+  TurnManager.advanceTurn(state);
+  expect(order).toEqual(['labor', 'suit']);
+  LaborManager.run = laborOriginal as any;
+  SuitabilityManager.run = suitOriginal as any;
+});

--- a/server/src/turn/manager.ts
+++ b/server/src/turn/manager.ts
@@ -4,6 +4,7 @@ import { BudgetManager } from '../budget/manager';
 import { LaborManager } from '../labor/manager';
 import { LogisticsManager } from '../logistics/manager';
 import { EnergyManager } from '../energy/manager';
+import { SuitabilityManager } from '../suitability/manager';
 
 /**
  * Orchestrates the two-phase turn resolution with a one-turn lag.
@@ -117,7 +118,7 @@ export class TurnManager {
   }
 
   private static suitabilityGate(_gameState: GameState): void {
-    // TODO: Apply suitability modifiers to running slots.
+    SuitabilityManager.run(_gameState.economy);
   }
 
   private static multiplySiteFactors(_gameState: GameState): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -93,6 +93,20 @@ export interface LaborPool {
   specialist: number;
 }
 
+// Terrain tile categories that compose a canton geography mix.
+export type TileType =
+  | 'plains'
+  | 'woods'
+  | 'hills'
+  | 'rainforest'
+  | 'wetlands'
+  | 'mountains'
+  | 'shallows'
+  | 'coast'
+  | 'river'
+  | 'tundra'
+  | 'desert';
+
 export type SectorType =
   | "agriculture"
   | "extraction"
@@ -170,6 +184,19 @@ export interface ShortageRecord {
   luxury: boolean;
 }
 
+export interface SuitabilityResult {
+  percent: number;
+  multiplier: number;
+}
+
+export type GeographyModifiers = Partial<
+  Record<SectorType, Partial<Record<TileType, number>>>
+>;
+
+export type UrbanizationModifiers = Partial<
+  Record<SectorType, Partial<Record<number, number>>>
+>;
+
 export interface CantonEconomy {
   sectors: { [K in SectorType]?: SectorState };
   labor: LaborPool;
@@ -179,7 +206,12 @@ export interface CantonEconomy {
   consumption: LaborConsumption;
   shortages: ShortageRecord;
   urbanizationLevel: number;
+  /** Geography mix for the canton; shares should sum to 1.0. */
+  geography: Record<TileType, number>;
+  /** Cached suitability percent by sector for ordering labor priority. */
   suitability: Partial<Record<SectorType, number>>;
+  /** Cached suitability multiplier by sector applied after all other gates. */
+  suitabilityMultipliers: Partial<Record<SectorType, number>>;
 }
 
 export interface EconomyState {


### PR DESCRIPTION
## Summary
- scaffold Suitability system with geography and urbanization modifiers
- cache and compute per-canton multipliers with clamping and rounding
- run Suitability after Labor gate and document new pass criteria

## Testing
- `bun test`
- `bun run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4a57c92b48327a7bef28b589cb0c5