### PR TITLE
Implement urbanization development scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,24 @@ The automated tests verify the following pass criteria:
 7. Suitability is applied only after the Labor gate and before output tallies.
 8. Changing UL or tile shares changes the computed suitability while unchanged inputs yield identical results across turns.
 9. Cached suitability invalidates when UL or tile shares change and remains stable otherwise.
+
+## Urbanization & Development System Scaffold
+
+This update introduces the Urbanization & Development scaffolding with:
+
+- Urbanization Level (UL) tracked per canton in the range 1–12
+- Per-canton Development Meter that advances toward UL increases
+- One-turn lag before UL changes affect other systems
+- Hooks that expose UL effects on sector slots, labor generation, and suitability modifiers
+- End-of-turn development rolls with modifier aggregation and per-turn caps
+- Flags that can trigger UL decay under persistent adverse conditions
+
+The automated tests verify the following pass criteria:
+
+1. UL and Development meter remain within their domains and meter rollover increases UL.
+2. Development roll modifiers aggregate with the base roll and respect per-turn caps.
+3. UL increases when the meter crosses 4, carrying remainder and applying next turn.
+4. Decay flags (siege, energy deficit, food deficit, catastrophe) each reduce UL by one, floor 1.
+5. Handoff tables expose sector slot, labor, and suitability effects by UL.
+6. End-of-turn processing is deterministic for identical inputs.
+7. Tests cover rollover, cap enforcement, UL boundaries, and all decay paths.

--- a/server/src/development/index.ts
+++ b/server/src/development/index.ts
@@ -1,0 +1,6 @@
+export {
+  DevelopmentManager,
+  SECTOR_SLOTS_BY_UL,
+  LABOR_BY_UL,
+  SUITABILITY_BY_UL,
+} from './manager';

--- a/server/src/development/manager.test.ts
+++ b/server/src/development/manager.test.ts
@@ -1,0 +1,91 @@
+import { expect, test, describe } from 'bun:test';
+import { EconomyManager } from '../economy';
+import { DevelopmentManager, SECTOR_SLOTS_BY_UL, LABOR_BY_UL, SUITABILITY_BY_UL } from './manager';
+import type { EconomyState } from '../types';
+
+function setup(): EconomyState {
+  const state = EconomyManager.createInitialState();
+  EconomyManager.addCanton(state, 'c1');
+  return state;
+}
+
+// 1. UL domain & meter
+
+test('UL and development meter stay within bounds', () => {
+  const state = setup();
+  // push meter to trigger UL increase
+  DevelopmentManager.run(state, { c1: { baseRoll: 5, cap: 4 } });
+  expect(state.cantons.c1.development).toBe(0);
+  expect(state.cantons.c1.nextUrbanizationLevel).toBe(2);
+  // apply next turn and ensure UL capped at 12
+  state.cantons.c1.urbanizationLevel = 12;
+  state.cantons.c1.nextUrbanizationLevel = 12;
+  DevelopmentManager.run(state, { c1: { baseRoll: 6, cap: 6 } });
+  expect(state.cantons.c1.development).toBe(4);
+  expect(state.cantons.c1.nextUrbanizationLevel).toBe(12);
+  // negative roll cannot drop meter below 0
+  state.cantons.c1.development = 3;
+  DevelopmentManager.run(state, { c1: { baseRoll: -10 } });
+  expect(state.cantons.c1.development).toBe(0);
+});
+
+// 2. Dev roll aggregation and cap
+
+test('development roll aggregates modifiers and respects cap', () => {
+  const state = setup();
+  DevelopmentManager.run(state, { c1: { baseRoll: 3, modifiers: [2, -1], cap: 3 } });
+  expect(state.cantons.c1.development).toBe(3);
+});
+
+// 3. UL increase with remainder and lag
+
+test('meter rollover increases UL next turn with remainder carried', () => {
+  const state = setup();
+  state.cantons.c1.development = 2;
+  DevelopmentManager.run(state, { c1: { baseRoll: 5, cap: 5 } });
+  expect(state.cantons.c1.development).toBe(3); // 2 + 5 =7 -> -4 =3
+  expect(state.cantons.c1.urbanizationLevel).toBe(1);
+  expect(state.cantons.c1.nextUrbanizationLevel).toBe(2);
+  DevelopmentManager.applyPending(state);
+  expect(state.cantons.c1.urbanizationLevel).toBe(2);
+  expect(state.cantons.c1.development).toBe(3);
+});
+
+// 4. UL decrease via decay flags
+
+describe('decay flags lower UL by one', () => {
+  const flags = ['siege', 'energy', 'food', 'catastrophe'] as const;
+  for (const flag of flags) {
+    test(`decay via ${flag}`, () => {
+      const state = setup();
+      state.cantons.c1.urbanizationLevel = 5;
+      DevelopmentManager.run(state, { c1: { baseRoll: 1, decayFlags: { [flag]: true } } });
+      expect(state.cantons.c1.nextUrbanizationLevel).toBe(4);
+      expect(state.cantons.c1.development).toBe(0);
+    });
+  }
+});
+
+// 5. Handoff hooks
+
+test('UL effect hooks are exposed', () => {
+  expect(SECTOR_SLOTS_BY_UL[1]).toBeDefined();
+  expect(SECTOR_SLOTS_BY_UL[12]).toBeDefined();
+  expect(LABOR_BY_UL[1]).toBeDefined();
+  expect(LABOR_BY_UL[12]).toBeDefined();
+  expect(SUITABILITY_BY_UL[1]).toBeDefined();
+  expect(SUITABILITY_BY_UL[12]).toBeDefined();
+});
+
+// 6. Determinism
+
+test('running with same inputs is deterministic', () => {
+  const make = () => {
+    const s = setup();
+    DevelopmentManager.run(s, { c1: { baseRoll: 4, modifiers: [1], cap: 5 } });
+    return JSON.stringify(s);
+  };
+  const first = make();
+  const second = make();
+  expect(second).toBe(first);
+});

--- a/server/src/development/manager.ts
+++ b/server/src/development/manager.ts
@@ -1,0 +1,68 @@
+import type { EconomyState, DecayFlags, LaborPool, SectorType } from '../types';
+
+/** Placeholder mapping of sector slot capacity by Urbanization Level. */
+export const SECTOR_SLOTS_BY_UL: Record<number, number> = Object.fromEntries(
+  Array.from({ length: 12 }, (_, i) => [i + 1, (i + 1) * 10]),
+);
+
+/** Placeholder labor generation mix by Urbanization Level. */
+export const LABOR_BY_UL: Record<number, LaborPool> = Object.fromEntries(
+  Array.from({ length: 12 }, (_, i) => [
+    i + 1,
+    {
+      general: (i + 1) * 5,
+      skilled: Math.floor((i + 1) * 1.5),
+      specialist: Math.floor((i + 1) / 2),
+    },
+  ]),
+);
+
+/** Placeholder suitability modifiers by Urbanization Level and sector. */
+export const SUITABILITY_BY_UL: Record<number, Partial<Record<SectorType, number>>> = Object.fromEntries(
+  Array.from({ length: 12 }, (_, i) => [i + 1, {}]),
+);
+
+export interface DevelopmentInput {
+  baseRoll: number;
+  modifiers?: number[];
+  cap?: number;
+  decayFlags?: DecayFlags;
+}
+
+/** Handles Development meter progress and Urbanization Level changes. */
+export class DevelopmentManager {
+  /** Apply development rolls and decay flags for all cantons. */
+  static run(economy: EconomyState, inputs: Record<string, DevelopmentInput>): void {
+    for (const [id, canton] of Object.entries(economy.cantons)) {
+      const input = inputs[id] ?? { baseRoll: 0 };
+      const mods = input.modifiers?.reduce((a, b) => a + b, 0) ?? 0;
+      let gain = input.baseRoll + mods;
+      if (typeof input.cap === 'number') gain = Math.min(gain, input.cap);
+      let meter = canton.development + gain;
+      if (meter < 0) meter = 0;
+      let nextUL = canton.urbanizationLevel;
+      const flags = input.decayFlags;
+      const decays = flags && (flags.siege || flags.energy || flags.food || flags.catastrophe);
+      if (decays) {
+        nextUL = Math.max(1, nextUL - 1);
+        meter = 0;
+      } else if (meter >= 4 && nextUL < 12) {
+        meter -= 4;
+        nextUL += 1;
+      }
+      if (meter > 4) meter = 4;
+      canton.development = meter;
+      canton.nextUrbanizationLevel = nextUL;
+    }
+  }
+
+  /** Apply any Urbanization Level changes that take effect this turn. */
+  static applyPending(economy: EconomyState): void {
+    for (const canton of Object.values(economy.cantons)) {
+      if (canton.nextUrbanizationLevel !== undefined) {
+        canton.urbanizationLevel = Math.max(1, Math.min(12, canton.nextUrbanizationLevel));
+      }
+    }
+  }
+}
+

--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -96,6 +96,8 @@ export class EconomyManager {
       },
       shortages: { food: false, luxury: false },
       urbanizationLevel: 1,
+      development: 0,
+      nextUrbanizationLevel: 1,
       geography: { plains: 1 },
       suitability: {},
       suitabilityMultipliers: {},

--- a/server/src/turn/manager.ts
+++ b/server/src/turn/manager.ts
@@ -5,6 +5,7 @@ import { LaborManager } from '../labor/manager';
 import { LogisticsManager } from '../logistics/manager';
 import { EnergyManager } from '../energy/manager';
 import { SuitabilityManager } from '../suitability/manager';
+import { DevelopmentManager } from '../development/manager';
 
 /**
  * Orchestrates the two-phase turn resolution with a one-turn lag.
@@ -84,9 +85,10 @@ export class TurnManager {
 
   // === Turn Flow Steps (placeholders) ===
 
-  private static carryover(_gameState: GameState): void {
+  private static carryover(gameState: GameState): void {
     // TODO: Projects advance, stock and rate updates.
-    BudgetManager.advanceRetools(_gameState.economy);
+    BudgetManager.advanceRetools(gameState.economy);
+    DevelopmentManager.applyPending(gameState.economy);
   }
 
   private static budgetGate(_gameState: GameState): void {
@@ -137,8 +139,9 @@ export class TurnManager {
     // TODO: Run the treasury waterfall and debt mechanics.
   }
 
-  private static resolveDevelopment(_gameState: GameState): void {
+  private static resolveDevelopment(gameState: GameState): void {
     // TODO: Roll for development and update urbanization levels.
+    DevelopmentManager.run(gameState.economy, {});
   }
 
   private static cleanup(_gameState: GameState): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -197,6 +197,14 @@ export type UrbanizationModifiers = Partial<
   Record<SectorType, Partial<Record<number, number>>>
 >;
 
+/** Flags that may trigger Urbanization Level decay at end of turn. */
+export interface DecayFlags {
+  siege?: boolean;
+  energy?: boolean;
+  food?: boolean;
+  catastrophe?: boolean;
+}
+
 export interface CantonEconomy {
   sectors: { [K in SectorType]?: SectorState };
   labor: LaborPool;
@@ -206,6 +214,15 @@ export interface CantonEconomy {
   consumption: LaborConsumption;
   shortages: ShortageRecord;
   urbanizationLevel: number;
+  /**
+   * Development meter advances toward the next Urbanization Level.
+   * Resets to 0 when reaching 4 and triggering a level increase.
+   */
+  development: number;
+  /**
+   * Urbanization Level that will become active next turn after lagged effects.
+   */
+  nextUrbanizationLevel: number;
   /** Geography mix for the canton; shares should sum to 1.0. */
   geography: Record<TileType, number>;
   /** Cached suitability percent by sector for ordering labor priority. */


### PR DESCRIPTION
## Summary
- add Urbanization & Development scaffolding with UL meter, decay flags, and lagged updates
- expose placeholder sector slot, labor, and suitability hooks by urbanization level
- wire development system into turn flow and include comprehensive tests

## Testing
- `cd server && bun test`
- `cd server && bun run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4afcac604832797cd10bd8e932301