### PR TITLE
Add infrastructure and capital project scaffolding

### DIFF
--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -77,6 +77,13 @@ export class EconomyManager {
         brownouts: [],
         essentialsFirst: false,
       },
+      infrastructure: {
+        airports: {},
+        ports: {},
+        railHubs: {},
+        national: {},
+      },
+      projects: { nextId: 1, projects: [] },
     };
   }
 

--- a/server/src/infrastructure/manager.test.ts
+++ b/server/src/infrastructure/manager.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from 'bun:test';
+import { EconomyManager } from '../economy/manager';
+import {
+  InfrastructureManager,
+  getInfraDefinition,
+} from './manager';
+import type { EconomyState } from '../types';
+
+function setupState(): EconomyState {
+  const state = EconomyManager.createInitialState();
+  EconomyManager.addCanton(state, 'A');
+  EconomyManager.addCanton(state, 'B');
+  EconomyManager.addCanton(state, 'C');
+  EconomyManager.addCanton(state, 'N'); // national locations
+  state.resources.gold = 10000;
+  state.resources.production = 10000;
+  return state;
+}
+
+// === Airport ===
+
+test('airport costs and provides 1-hop air link via national airport', () => {
+  expect(getInfraDefinition('airport')).toEqual({
+    build: { gold: 120, production: 80, time: 3 },
+    oAndM: { gold: 4, energy: 2 },
+  });
+  const state = setupState();
+  InfrastructureManager.build(state, 'airport', 'N', { national: true });
+  InfrastructureManager.build(state, 'airport', 'A');
+  for (let i = 0; i < 4; i++) InfrastructureManager.progressTurn(state);
+  const result = InfrastructureManager.computeNetworks(state);
+  expect(result.networks['A']!.air!.hops).toBe(1);
+  expect(result.gatewayCapacities.air).toBeDefined();
+});
+
+// === Port ===
+
+test('port auto-connects, adds LP and handles capture/repair', () => {
+  const def = getInfraDefinition('port');
+  expect(def).toEqual({
+    build: { gold: 140, production: 100, time: 3 },
+    oAndM: { gold: 3, energy: 2 },
+  });
+  const state = setupState();
+  InfrastructureManager.build(state, 'port', 'N', { national: true });
+  InfrastructureManager.build(state, 'port', 'A');
+  InfrastructureManager.build(state, 'port', 'B');
+  InfrastructureManager.build(state, 'port', 'C');
+  const ctx = {
+    portDistances: {
+      N: { A: 5, B: 12, C: 30 },
+      A: { N: 5, B: 8, C: 40 },
+      B: { N: 12, A: 8, C: 10 },
+      C: { B: 10, N: 30 },
+    },
+  };
+  for (let i = 0; i < 4; i++) InfrastructureManager.progressTurn(state, ctx);
+  const result = InfrastructureManager.computeNetworks(state, ctx);
+  expect(result.networks['C']!.sea!.hops).toBe(2); // via B -> N
+  expect(result.lpBonus).toBe(40); // 4 ports * 10 LP
+  expect(result.gatewayCapacities.port).toBeDefined();
+  const unit = { stockpile: 5, maxStockpile: 10 };
+  InfrastructureManager.navalResupply(unit);
+  expect(unit.stockpile).toBe(10);
+  // capture and repair
+  state.infrastructure.ports['A'].hp = 50;
+  InfrastructureManager.capture(state, 'port', 'A', 'Enemy');
+  expect(state.infrastructure.ports['A'].owner).toBe('Enemy');
+  InfrastructureManager.pillage(state, 'port', 'A');
+  state.resources.production = 10;
+  InfrastructureManager.repair(state, 'port', 'A');
+  expect(state.resources.production).toBe(5);
+  expect(state.infrastructure.ports['A'].hp).toBe(100);
+});
+
+// === Rail Hub ===
+
+test('rail hubs link only via valid adjacency and provide min speed 4', () => {
+  const def = getInfraDefinition('rail');
+  expect(def).toEqual({
+    build: { gold: 60, production: 45, time: 2 },
+    oAndM: { gold: 2, energy: 1 },
+  });
+  const state = setupState();
+  InfrastructureManager.build(state, 'rail', 'N', { national: true });
+  InfrastructureManager.build(state, 'rail', 'A');
+  InfrastructureManager.build(state, 'rail', 'B');
+  InfrastructureManager.build(state, 'rail', 'C');
+  const ctx = {
+    railAdjacency: {
+      N: { A: 'plains', B: 'mountains' },
+      A: { N: 'plains', C: 'plains' },
+      B: { N: 'mountains' },
+      C: { A: 'plains', B: 'shallows' },
+    },
+  };
+  for (let i = 0; i < 3; i++) InfrastructureManager.progressTurn(state, ctx);
+  const result = InfrastructureManager.computeNetworks(state, ctx);
+  expect(result.networks['B']!.rail!.connected).toBe(false);
+  expect(result.networks['C']!.rail!.hops).toBe(2); // C->A->N
+  const speed = InfrastructureManager.railMovementSpeed(2, ['C', 'A', 'N'], state, ctx);
+  expect(speed).toBe(4);
+  InfrastructureManager.pillage(state, 'rail', 'A');
+  InfrastructureManager.progressTurn(state, ctx);
+  const result2 = InfrastructureManager.computeNetworks(state, ctx);
+  expect(result2.networks['C']!.rail!.connected).toBe(false);
+  state.resources.production = 10;
+  InfrastructureManager.repair(state, 'rail', 'A');
+  InfrastructureManager.progressTurn(state, ctx);
+  const result3 = InfrastructureManager.computeNetworks(state, ctx);
+  expect(result3.networks['C']).toBeDefined();
+});
+
+// === National Variants ===
+
+test('national variants enforce uniqueness and multipliers', () => {
+  const base = getInfraDefinition('airport');
+  const nat = getInfraDefinition('airport', true);
+  expect(nat.build.gold).toBeCloseTo(base.build.gold * 1.5);
+  expect(nat.oAndM.gold).toBe(base.oAndM.gold * 2);
+  const state = setupState();
+  InfrastructureManager.build(state, 'airport', 'N', { national: true });
+  expect(() =>
+    InfrastructureManager.build(state, 'airport', 'B', { national: true }),
+  ).toThrow();
+});
+
+// === On/Off timing ===
+
+test('turning infrastructure on/off takes a full turn', () => {
+  const state = setupState();
+  InfrastructureManager.build(state, 'port', 'N', { national: true });
+  for (let i = 0; i < 4; i++) InfrastructureManager.progressTurn(state);
+  expect(state.infrastructure.ports['N'].status).toBe('active');
+  InfrastructureManager.toggle(state, 'port', 'N', 'inactive');
+  expect(state.infrastructure.ports['N'].status).toBe('active');
+  InfrastructureManager.progressTurn(state);
+  expect(state.infrastructure.ports['N'].status).toBe('inactive');
+});

--- a/server/src/infrastructure/manager.ts
+++ b/server/src/infrastructure/manager.ts
@@ -1,0 +1,312 @@
+// server/src/infrastructure/manager.ts
+import type {
+  EconomyState,
+  InfrastructureType,
+  InfrastructureData,
+} from '../types';
+import type { Mode, NetworkNode, Gateway } from '../logistics/manager';
+
+export interface InfraDefinition {
+  build: { gold: number; production: number; time: number };
+  oAndM: { gold: number; energy: number };
+}
+
+export const INFRA_DEFINITIONS: Record<InfrastructureType, InfraDefinition> = {
+  airport: {
+    build: { gold: 120, production: 80, time: 3 },
+    oAndM: { gold: 4, energy: 2 },
+  },
+  port: {
+    build: { gold: 140, production: 100, time: 3 },
+    oAndM: { gold: 3, energy: 2 },
+  },
+  rail: {
+    build: { gold: 60, production: 45, time: 2 },
+    oAndM: { gold: 2, energy: 1 },
+  },
+};
+
+export function getInfraDefinition(
+  type: InfrastructureType,
+  national = false,
+): InfraDefinition {
+  const base = INFRA_DEFINITIONS[type];
+  if (!national) return base;
+  return {
+    build: {
+      gold: Math.round(base.build.gold * 1.5),
+      production: Math.round(base.build.production * 1.5),
+      time: base.build.time,
+    },
+    oAndM: {
+      gold: base.oAndM.gold * 2,
+      energy: base.oAndM.energy * 2,
+    },
+  };
+}
+
+export interface NetworkBuildContext {
+  portDistances?: Record<string, Record<string, number>>;
+  railAdjacency?: Record<string, Record<string, string>>;
+}
+
+function bfs(graph: Record<string, string[]>, start?: string): Record<string, number> {
+  const dist: Record<string, number> = {};
+  if (!start) return dist;
+  const q: string[] = [start];
+  dist[start] = 0;
+  while (q.length) {
+    const cur = q.shift()!;
+    for (const nb of graph[cur] || []) {
+      if (dist[nb] !== undefined) continue;
+      dist[nb] = dist[cur] + 1;
+      q.push(nb);
+    }
+  }
+  return dist;
+}
+
+function plural(type: InfrastructureType): 'airports' | 'ports' | 'railHubs' {
+  return type === 'airport' ? 'airports' : type === 'port' ? 'ports' : 'railHubs';
+}
+
+export interface NavalUnit {
+  stockpile: number;
+  maxStockpile: number;
+}
+
+export class InfrastructureManager {
+  static build(
+    state: EconomyState,
+    type: InfrastructureType,
+    canton: string,
+    opts: { national?: boolean; owner?: string } = {},
+  ): void {
+    const def = getInfraDefinition(type, opts.national);
+    if (opts.national) {
+      const current = state.infrastructure.national;
+      const key = type === 'airport' ? 'airport' : type === 'port' ? 'port' : 'rail';
+      if ((current as any)[key]) {
+        throw new Error(`National ${type} already exists`);
+      }
+      (state.infrastructure.national as any)[key] = canton;
+    }
+    const entry: InfrastructureData = {
+      owner: opts.owner ?? 'national',
+      status: 'building',
+      national: opts.national ?? false,
+      turns_remaining: def.build.time,
+      hp: 100,
+    };
+    (state.infrastructure[plural(type)] as any)[canton] = entry;
+    state.resources.gold -= def.build.gold;
+    state.resources.production -= def.build.production;
+  }
+
+  static toggle(
+    state: EconomyState,
+    type: InfrastructureType,
+    canton: string,
+    target: 'active' | 'inactive',
+  ): void {
+    const entry = (state.infrastructure[plural(type)] as any)[canton] as
+      | InfrastructureData
+      | undefined;
+    if (!entry) return;
+    entry.toggle = { target, turns: 1 };
+  }
+
+  static pillage(
+    state: EconomyState,
+    type: InfrastructureType,
+    canton: string,
+  ): void {
+    const entry = (state.infrastructure[plural(type)] as any)[canton] as
+      | InfrastructureData
+      | undefined;
+    if (!entry) return;
+    entry.hp = 0;
+    entry.status = 'inactive';
+  }
+
+  static repair(
+    state: EconomyState,
+    type: InfrastructureType,
+    canton: string,
+  ): void {
+    const entry = (state.infrastructure[plural(type)] as any)[canton] as
+      | InfrastructureData
+      | undefined;
+    if (!entry) return;
+    if (state.resources.production < 5) throw new Error('insufficient production');
+    state.resources.production -= 5;
+    entry.hp = 100;
+    if (entry.status !== 'building') entry.status = 'active';
+  }
+
+  static capture(
+    state: EconomyState,
+    type: InfrastructureType,
+    canton: string,
+    newOwner: string,
+  ): void {
+    const entry = (state.infrastructure[plural(type)] as any)[canton] as
+      | InfrastructureData
+      | undefined;
+    if (!entry) return;
+    entry.owner = newOwner;
+  }
+
+  static navalResupply(unit: NavalUnit): void {
+    unit.stockpile = unit.maxStockpile;
+  }
+
+  static progressTurn(
+    state: EconomyState,
+    ctx: NetworkBuildContext = {},
+  ): {
+    networks: Record<string, Partial<Record<Mode, NetworkNode>>>;
+    gatewayCapacities: Partial<Record<Gateway, number>>;
+    lpBonus: number;
+  } {
+    for (const list of [
+      state.infrastructure.airports,
+      state.infrastructure.ports,
+      state.infrastructure.railHubs,
+    ]) {
+      for (const entry of Object.values(list)) {
+        if (entry.status === 'building') {
+          entry.turns_remaining! -= 1;
+          if (entry.turns_remaining! <= 0) {
+            entry.status = 'inactive';
+            entry.toggle = { target: 'active', turns: 1 };
+            entry.turns_remaining = 0;
+          }
+        }
+        if (entry.toggle) {
+          entry.toggle.turns -= 1;
+          if (entry.toggle.turns <= 0) {
+            entry.status = entry.toggle.target;
+            entry.toggle = undefined;
+          }
+        }
+      }
+    }
+    return this.computeNetworks(state, ctx);
+  }
+
+  static computeNetworks(
+    state: EconomyState,
+    ctx: NetworkBuildContext = {},
+  ) {
+    const networks: Record<string, Partial<Record<Mode, NetworkNode>>> = {};
+    const gatewayCapacities: Partial<Record<Gateway, number>> = {};
+    let lpBonus = 0;
+
+    // Airports
+    const natAirport = state.infrastructure.national.airport;
+    if (natAirport && state.infrastructure.airports[natAirport]?.status === 'active') {
+      gatewayCapacities.air = Infinity;
+    }
+    for (const [canton, air] of Object.entries(state.infrastructure.airports)) {
+      if (air.status !== 'active') continue;
+      const hops = natAirport ? (canton === natAirport ? 0 : 1) : Infinity;
+      networks[canton] = networks[canton] || {};
+      networks[canton].air = {
+        connected: hops !== Infinity,
+        hops,
+        capacity_per_turn: Infinity,
+      };
+    }
+
+    // Ports graph
+    const activePorts = Object.entries(state.infrastructure.ports).filter(
+      ([, p]) => p.status === 'active',
+    );
+    const portGraph: Record<string, string[]> = {};
+    for (const [id] of activePorts) portGraph[id] = [];
+    for (const [id] of activePorts) {
+      const distances = ctx.portDistances?.[id] || {};
+      const candidates = Object.entries(distances)
+        .filter(([other, d]) => portGraph[other] && d <= 15)
+        .sort((a, b) => a[1] - b[1])
+        .slice(0, 2);
+      for (const [other] of candidates) {
+        portGraph[id].push(other);
+        portGraph[other].push(id);
+      }
+    }
+    const natPort = state.infrastructure.national.port;
+    const portDist = bfs(portGraph, natPort);
+    if (natPort && state.infrastructure.ports[natPort]?.status === 'active') {
+      gatewayCapacities.port = Infinity;
+    }
+    for (const [id, p] of activePorts) {
+      networks[id] = networks[id] || {};
+      const hops = portDist[id];
+      networks[id].sea = {
+        connected: hops !== undefined,
+        hops: hops ?? Infinity,
+        capacity_per_turn: Infinity,
+      };
+      lpBonus += 10;
+    }
+
+    // Rail graph
+    const activeRails = Object.entries(state.infrastructure.railHubs).filter(
+      ([, h]) => h.status === 'active' && h.hp > 0,
+    );
+    const railGraph: Record<string, string[]> = {};
+    for (const [id] of activeRails) railGraph[id] = [];
+    const forbids = new Set(['mountains', 'shallows', 'deep_ocean', 'deepOcean']);
+    for (const [id] of activeRails) {
+      const adj = ctx.railAdjacency?.[id] || {};
+      for (const [nb, terrain] of Object.entries(adj)) {
+        if (!railGraph[nb]) continue; // neighbor lacks active hub
+        if (forbids.has(terrain)) continue;
+        railGraph[id].push(nb);
+      }
+    }
+    const natRail = state.infrastructure.national.rail;
+    const railDist = bfs(railGraph, natRail);
+    if (natRail && state.infrastructure.railHubs[natRail]?.status === 'active') {
+      gatewayCapacities.rail = Infinity;
+    }
+    for (const [id] of activeRails) {
+      networks[id] = networks[id] || {};
+      const hops = railDist[id];
+      networks[id].rail = {
+        connected: hops !== undefined,
+        hops: hops ?? Infinity,
+        capacity_per_turn: Infinity,
+      };
+    }
+
+    return { networks, gatewayCapacities, lpBonus };
+  }
+
+  static railMovementSpeed(
+    unitSpeed: number,
+    path: string[],
+    state: EconomyState,
+    ctx: NetworkBuildContext,
+  ): number {
+    // path is sequence of cantons including start and end
+    for (let i = 0; i < path.length; i++) {
+      const c = path[i];
+      const hub = state.infrastructure.railHubs[c];
+      if (!hub || hub.status !== 'active' || hub.hp <= 0) return unitSpeed;
+      if (i < path.length - 1) {
+        const next = path[i + 1];
+        const terr = ctx.railAdjacency?.[c]?.[next];
+        if (!terr) return unitSpeed;
+        const forbids = new Set(['mountains', 'shallows', 'deep_ocean', 'deepOcean']);
+        if (forbids.has(terr)) return unitSpeed;
+        const nextHub = state.infrastructure.railHubs[next];
+        if (!nextHub || nextHub.status !== 'active' || nextHub.hp <= 0)
+          return unitSpeed;
+      }
+    }
+    return Math.max(unitSpeed, 4);
+  }
+}

--- a/server/src/projects/manager.test.ts
+++ b/server/src/projects/manager.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from 'bun:test';
+import { EconomyManager } from '../economy/manager';
+import { ProjectsManager, getProjectDefinition } from './manager';
+import type { EconomyState } from '../types';
+
+function setup(): EconomyState {
+  const s = EconomyManager.createInitialState();
+  EconomyManager.addCanton(s, 'A');
+  s.resources.gold = 10000;
+  s.resources.production = 10000;
+  return s;
+}
+
+// === Definitions coverage ===
+
+test('project tier definitions and start for each tier', () => {
+  expect(getProjectDefinition('small')).toEqual({
+    slots: 1,
+    build: { gold: 50, production: 20, time: 2 },
+    oAndM: { gold: 1, energy: 1 },
+  });
+  expect(getProjectDefinition('medium').slots).toBe(2);
+  expect(getProjectDefinition('large').build.production).toBe(100);
+  expect(getProjectDefinition('mega').oAndM.energy).toBe(5);
+  const state = setup();
+  ProjectsManager.start(state, 'A', 'agriculture', 'small');
+  ProjectsManager.start(state, 'A', 'agriculture', 'medium');
+  ProjectsManager.start(state, 'A', 'agriculture', 'large');
+  ProjectsManager.start(state, 'A', 'agriculture', 'mega');
+  expect(state.projects.projects.length).toBe(4);
+});
+
+// === Delays ===
+
+test('construction delays apply for deficits and debt stress', () => {
+  const state = setup();
+  const id1 = ProjectsManager.start(state, 'A', 'agriculture', 'small');
+  const id2 = ProjectsManager.start(state, 'A', 'agriculture', 'small');
+  ProjectsManager.advance(state, { energyDeficit: true });
+  expect(state.projects.projects.find(p=>p.id===id1)!.turns_remaining).toBe(2);
+  ProjectsManager.advance(state, { lpDeficit: true });
+  expect(state.projects.projects.find(p=>p.id===id1)!.turns_remaining).toBe(2);
+  ProjectsManager.advance(state, { debtStress: true });
+  const p1 = state.projects.projects.find(p=>p.id===id1)!;
+  const p2 = state.projects.projects.find(p=>p.id===id2)!;
+  expect(p1.turns_remaining).toBe(2); // first project delayed
+  expect(p2.turns_remaining).toBe(1); // second progressed normally
+});
+
+// === Suspend/Cancel ===
+
+test('projects can suspend, resume and cancel with refunds', () => {
+  const state = setup();
+  const id = ProjectsManager.start(state, 'A', 'agriculture', 'medium');
+  const proj = state.projects.projects.find(p=>p.id===id)!;
+  ProjectsManager.suspend(state, id);
+  ProjectsManager.advance(state);
+  expect(proj.turns_remaining).toBe(getProjectDefinition('medium').build.time);
+  ProjectsManager.resume(state, id);
+  ProjectsManager.advance(state);
+  expect(proj.turns_remaining).toBe(getProjectDefinition('medium').build.time - 1);
+  const productionBefore = state.resources.production;
+  ProjectsManager.cancel(state, id);
+  expect(state.projects.projects.find(p=>p.id===id)).toBeUndefined();
+  expect(state.resources.production).toBe(
+    productionBefore + Math.floor(getProjectDefinition('medium').build.production * 0.25),
+  );
+});
+
+// === Capture ===
+
+test('capture transfers completed capacity and pauses builds', () => {
+  const state = setup();
+  const id = ProjectsManager.start(state, 'A', 'agriculture', 'small');
+  for (let i = 0; i < 2; i++) ProjectsManager.advance(state); // finish build
+  ProjectsManager.advance(state); // activate
+  const canton = state.cantons['A'];
+  const capacityBefore = canton.sectors.agriculture!.capacity;
+  ProjectsManager.capture(state, id, 'Enemy');
+  expect(state.projects.projects[0].owner).toBe('Enemy');
+  expect(canton.sectors.agriculture!.capacity).toBe(capacityBefore);
+  const id2 = ProjectsManager.start(state, 'A', 'agriculture', 'small');
+  ProjectsManager.capture(state, id2, 'Enemy');
+  expect(state.projects.projects.find(p=>p.id===id2)!.status).toBe('suspended');
+  ProjectsManager.resume(state, id2);
+  ProjectsManager.advance(state);
+  expect(state.projects.projects.find(p=>p.id===id2)!.turns_remaining).toBe(
+    getProjectDefinition('small').build.time - 1,
+  );
+});
+
+// === On/off timing ===
+
+test('project activation and deactivation take a full turn', () => {
+  const state = setup();
+  const id = ProjectsManager.start(state, 'A', 'agriculture', 'small');
+  for (let i = 0; i < 2; i++) ProjectsManager.advance(state);
+  // completed but waiting to activate
+  expect(state.projects.projects.find(p=>p.id===id)!.status).toBe('inactive');
+  ProjectsManager.advance(state); // activation
+  const proj = state.projects.projects.find(p=>p.id===id)!;
+  expect(proj.status).toBe('active');
+  const cap = state.cantons['A'].sectors.agriculture!.capacity;
+  ProjectsManager.toggle(state, id, 'inactive');
+  ProjectsManager.advance(state); // toggle resolves
+  expect(proj.status).toBe('inactive');
+  expect(state.cantons['A'].sectors.agriculture!.capacity).toBe(cap - proj.slots);
+});

--- a/server/src/projects/manager.ts
+++ b/server/src/projects/manager.ts
@@ -1,0 +1,151 @@
+// server/src/projects/manager.ts
+import type { EconomyState, ProjectTier, ProjectData, SectorType } from '../types';
+
+export interface ProjectDefinition {
+  slots: number;
+  build: { gold: number; production: number; time: number };
+  oAndM: { gold: number; energy: number };
+}
+
+export const PROJECT_DEFINITIONS: Record<ProjectTier, ProjectDefinition> = {
+  small: {
+    slots: 1,
+    build: { gold: 50, production: 20, time: 2 },
+    oAndM: { gold: 1, energy: 1 },
+  },
+  medium: {
+    slots: 2,
+    build: { gold: 100, production: 35, time: 3 },
+    oAndM: { gold: 2, energy: 2 },
+  },
+  large: {
+    slots: 4,
+    build: { gold: 150, production: 100, time: 4 },
+    oAndM: { gold: 3, energy: 3 },
+  },
+  mega: {
+    slots: 6,
+    build: { gold: 300, production: 200, time: 6 },
+    oAndM: { gold: 5, energy: 5 },
+  },
+};
+
+export function getProjectDefinition(tier: ProjectTier): ProjectDefinition {
+  return PROJECT_DEFINITIONS[tier];
+}
+
+export interface ProjectAdvanceContext {
+  energyDeficit?: boolean;
+  lpDeficit?: boolean;
+  debtStress?: boolean;
+}
+
+function applyCapacity(state: EconomyState, project: ProjectData, enable: boolean) {
+  const canton = state.cantons[project.canton];
+  if (!canton) return;
+  const sec = (canton.sectors as any)[project.sector];
+  if (!sec) return;
+  if (enable) {
+    sec.capacity += project.slots;
+  } else {
+    sec.capacity -= project.slots;
+  }
+}
+
+export class ProjectsManager {
+  static start(
+    state: EconomyState,
+    canton: string,
+    sector: SectorType,
+    tier: ProjectTier,
+    owner = 'national',
+  ): number {
+    const def = getProjectDefinition(tier);
+    state.resources.gold -= def.build.gold;
+    state.resources.production -= def.build.production;
+    const project: ProjectData = {
+      id: state.projects.nextId++,
+      canton,
+      sector,
+      tier,
+      slots: def.slots,
+      status: 'building',
+      owner,
+      turns_remaining: def.build.time,
+      cost: { ...def.build },
+      completed: false,
+    };
+    state.projects.projects.push(project);
+    // ensure sector exists
+    const cantonEco = state.cantons[canton];
+    if (cantonEco && !cantonEco.sectors[sector]) {
+      cantonEco.sectors[sector] = { capacity: 0, funded: 0, idle: 0 } as any;
+    }
+    return project.id;
+  }
+
+  static advance(state: EconomyState, ctx: ProjectAdvanceContext = {}): void {
+    let debtApplied = false;
+    for (const project of state.projects.projects) {
+      if (project.toggle) {
+        project.toggle.turns -= 1;
+        if (project.toggle.turns <= 0) {
+          project.status = project.toggle.target;
+          project.toggle = undefined;
+          if (project.completed) {
+            applyCapacity(state, project, project.status === 'active');
+          }
+        }
+      }
+      if (project.status !== 'building') continue;
+      let penalty = 0;
+      if (ctx.energyDeficit) penalty++;
+      if (ctx.lpDeficit) penalty++;
+      if (ctx.debtStress && !debtApplied) {
+        penalty++;
+        debtApplied = true;
+      }
+      project.turns_remaining += penalty;
+      project.turns_remaining -= 1;
+      if (project.turns_remaining <= 0) {
+        project.completed = true;
+        project.status = 'inactive';
+        project.turns_remaining = 0;
+        project.toggle = { target: 'active', turns: 1 };
+      }
+    }
+  }
+
+  static toggle(state: EconomyState, id: number, target: 'active' | 'inactive'): void {
+    const project = state.projects.projects.find((p) => p.id === id);
+    if (!project) return;
+    project.toggle = { target, turns: 1 };
+  }
+
+  static suspend(state: EconomyState, id: number): void {
+    const project = state.projects.projects.find((p) => p.id === id);
+    if (!project) return;
+    if (project.status === 'building') project.status = 'suspended';
+  }
+
+  static resume(state: EconomyState, id: number): void {
+    const project = state.projects.projects.find((p) => p.id === id);
+    if (!project) return;
+    if (project.status === 'suspended') project.status = 'building';
+  }
+
+  static cancel(state: EconomyState, id: number): void {
+    const idx = state.projects.projects.findIndex((p) => p.id === id);
+    if (idx === -1) return;
+    const project = state.projects.projects[idx];
+    state.resources.production += Math.floor(project.cost.production * 0.25);
+    state.projects.projects.splice(idx, 1);
+  }
+
+  static capture(state: EconomyState, id: number, newOwner: string): void {
+    const project = state.projects.projects.find((p) => p.id === id);
+    if (!project) return;
+    project.owner = newOwner;
+    if (project.status === 'building') project.status = 'suspended';
+  }
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -231,6 +231,45 @@ export interface CantonEconomy {
   suitabilityMultipliers: Partial<Record<SectorType, number>>;
 }
 
+export type InfrastructureType = 'airport' | 'port' | 'rail';
+
+export interface InfrastructureData {
+  owner: string;
+  status: 'active' | 'inactive' | 'building';
+  national?: boolean;
+  turns_remaining?: number;
+  hp: number;
+  toggle?: { target: 'active' | 'inactive'; turns: number };
+}
+
+export interface InfrastructureRegistry {
+  airports: Record<string, InfrastructureData>;
+  ports: Record<string, InfrastructureData>;
+  railHubs: Record<string, InfrastructureData>;
+  national: { airport?: string; port?: string; rail?: string };
+}
+
+export type ProjectTier = 'small' | 'medium' | 'large' | 'mega';
+
+export interface ProjectData {
+  id: number;
+  canton: string;
+  sector: SectorType;
+  tier: ProjectTier;
+  slots: number;
+  status: 'active' | 'inactive' | 'building' | 'suspended';
+  owner: string;
+  turns_remaining: number;
+  cost: { gold: number; production: number };
+  toggle?: { target: 'active' | 'inactive'; turns: number };
+  completed?: boolean;
+}
+
+export interface ProjectsState {
+  nextId: number;
+  projects: ProjectData[];
+}
+
 export interface EconomyState {
   resources: Resources;
   cantons: { [cantonId: string]: CantonEconomy };
@@ -244,6 +283,10 @@ export interface EconomyState {
     brownouts: BrownoutRecord[];
     essentialsFirst: boolean;
   };
+  /** Infrastructure registry */
+  infrastructure: InfrastructureRegistry;
+  /** Capital projects state */
+  projects: ProjectsState;
 }
 
 export interface RetoolOrder {


### PR DESCRIPTION
## Summary
- define airport, port, and rail hub infrastructure with build costs, O&M, toggles, capture/repair logic, and network generation
- add tiered capital project system with delays, suspend/cancel, on/off behavior, and capture handling
- track infrastructure and project state in EconomyState and cover with extensive unit tests

## Testing
- `cd server && npx --yes bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b3fb9f5c832794f066fe3b8e89e3