### PR TITLE
Add finance system scaffolding with debt and treasury mechanics

### DIFF
--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -84,6 +84,13 @@ export class EconomyManager {
         national: {},
       },
       projects: { nextId: 1, projects: [] },
+      finance: {
+        debt: 0,
+        creditLimit: 1000,
+        interestRate: 0.05,
+        defaulted: false,
+        debtStress: [],
+      },
     };
   }
 

--- a/server/src/finance/manager.test.ts
+++ b/server/src/finance/manager.test.ts
@@ -1,0 +1,127 @@
+import { test, expect, spyOn } from 'bun:test';
+import { EconomyManager } from '../economy';
+import { FinanceManager } from './manager';
+import { TurnManager } from '../turn/manager';
+import { DevelopmentManager } from '../development/manager';
+import type { EconomyState, GameState, TurnPlan } from '../types';
+
+function createEconomy(): EconomyState {
+  const state = EconomyManager.createInitialState();
+  state.finance.creditLimit = 500;
+  state.finance.interestRate = 0.1;
+  return state;
+}
+
+// 1. Treasury accounting
+ test('treasury updates with revenues and expenditures', () => {
+  const eco = createEconomy();
+  eco.resources.gold = 100;
+  FinanceManager.run(eco, { revenues: 50, expenditures: 30 });
+  expect(eco.resources.gold).toBe(120);
+  expect(eco.finance.debt).toBe(0);
+});
+
+// 2. Auto-borrowing
+test('auto-borrowing covers treasury shortfalls', () => {
+  const eco = createEconomy();
+  eco.finance.interestRate = 0;
+  FinanceManager.run(eco, { revenues: 0, expenditures: 50 });
+  expect(eco.resources.gold).toBe(0);
+  expect(eco.finance.debt).toBe(50);
+});
+
+// 3. Debt accumulation
+test('borrowing increases debt immediately', () => {
+  const eco = createEconomy();
+  eco.finance.interestRate = 0;
+  eco.finance.debt = 20;
+  FinanceManager.run(eco, { revenues: 0, expenditures: 30 });
+  expect(eco.finance.debt).toBe(50);
+});
+
+// 4. Interest application
+ test('interest tick adds to debt and expenditures', () => {
+  const eco = createEconomy();
+  eco.resources.gold = 20;
+  eco.finance.debt = 100;
+  FinanceManager.run(eco, { revenues: 0, expenditures: 0 });
+  expect(Math.round(eco.resources.gold)).toBe(10);
+  expect(Math.round(eco.finance.debt)).toBe(110);
+});
+
+// 5. Credit limit enforcement
+ test('exceeding credit limit triggers default', () => {
+  const eco = createEconomy();
+  eco.finance.creditLimit = 100;
+  eco.finance.debt = 90;
+  FinanceManager.run(eco, { revenues: 0, expenditures: 20 });
+  expect(eco.finance.defaulted).toBeTrue();
+});
+
+// 6. Debt stress flags
+ test('debt stress tiers flag when thresholds crossed', () => {
+  const eco = createEconomy();
+  FinanceManager.run(eco, { revenues: 0, expenditures: 60 });
+  expect(eco.finance.debtStress[0]).toBeTrue();
+  eco.finance.debt = 90;
+  FinanceManager.run(eco, { revenues: 0, expenditures: 20 });
+  expect(eco.finance.debtStress[1]).toBeTrue();
+  eco.finance.debt = 190;
+  FinanceManager.run(eco, { revenues: 0, expenditures: 20 });
+  expect(eco.finance.debtStress[2]).toBeTrue();
+});
+
+// 7. Sequencing with development
+ test('finance resolves before development', () => {
+  const plan: TurnPlan = { budgets: { military: 0, welfare: 0, sectorOM: {} } };
+  const gs: GameState = {
+    status: 'in_progress',
+    currentPlayer: 'P1',
+    turnNumber: 1,
+    phase: 'planning',
+    currentPlan: plan,
+    nextPlan: null,
+    cellOwnership: {},
+    playerCells: {},
+    entities: {},
+    cellEntities: {},
+    playerEntities: {},
+    entitiesByType: { unit: [] },
+    economy: createEconomy(),
+    nextEntityId: 1,
+  } as GameState;
+
+  const order: string[] = [];
+  const finSpy = spyOn(FinanceManager, 'run').mockImplementation((e, i) => {
+    order.push('finance');
+  });
+  const devSpy = spyOn(DevelopmentManager, 'run').mockImplementation((e, i) => {
+    order.push('development');
+  });
+
+  TurnManager.advanceTurn(gs);
+  expect(order).toEqual(['finance', 'development']);
+
+  finSpy.mockRestore();
+  devSpy.mockRestore();
+});
+
+// 8. Determinism
+ test('finance resolution is deterministic', () => {
+  const a = createEconomy();
+  const b = createEconomy();
+  FinanceManager.run(a, { revenues: 10, expenditures: 40 });
+  FinanceManager.run(b, { revenues: 10, expenditures: 40 });
+  expect(a.resources.gold).toBe(b.resources.gold);
+  expect(a.finance.debt).toBe(b.finance.debt);
+  expect(a.finance.defaulted).toBe(b.finance.defaulted);
+  expect(a.finance.debtStress).toEqual(b.finance.debtStress);
+});
+
+// 9. Coverage scenarios
+ test('handles surplus treasury without borrowing', () => {
+  const eco = createEconomy();
+  eco.resources.gold = 100;
+  FinanceManager.run(eco, { revenues: 50, expenditures: 20 });
+  expect(eco.finance.debt).toBe(0);
+});

--- a/server/src/finance/manager.ts
+++ b/server/src/finance/manager.ts
@@ -1,0 +1,55 @@
+// server/src/finance/manager.ts
+import type { EconomyState } from '../types';
+
+/** Debt stress tier thresholds. */
+export const DEBT_STRESS_TIERS = [50, 100, 200];
+
+export interface FinanceInput {
+  revenues: number;
+  expenditures: number;
+}
+
+/**
+ * Handles treasury accounting, auto-borrowing, interest application,
+ * credit limit enforcement, and debt stress flags.
+ */
+export class FinanceManager {
+  /** Run the finance resolution sequence for the turn. */
+  static run(economy: EconomyState, input: FinanceInput): void {
+    const finance = economy.finance;
+    // Step 1: apply revenues and expenditures
+    economy.resources.gold += input.revenues - input.expenditures;
+
+    // Step 2 & 3: auto-borrow if needed and update debt
+    this.autoBorrow(economy);
+
+    // Step 4: apply interest tick
+    const interest = finance.debt * finance.interestRate;
+    economy.resources.gold -= interest;
+    finance.debt += interest;
+    // Borrow again if interest payment caused deficit
+    this.autoBorrow(economy);
+
+    // Step 5: credit limit check
+    if (finance.debt > finance.creditLimit) {
+      finance.defaulted = true;
+    }
+
+    // Step 6: debt stress tier flags
+    finance.debtStress = DEBT_STRESS_TIERS.map((t) => finance.debt >= t);
+  }
+
+  /** Borrow automatically to cover treasury shortfalls. */
+  private static autoBorrow(economy: EconomyState): void {
+    const finance = economy.finance;
+    if (economy.resources.gold >= 0) return;
+    const needed = -economy.resources.gold;
+    const available = finance.creditLimit - finance.debt;
+    const borrow = Math.min(needed, available);
+    finance.debt += borrow;
+    economy.resources.gold += borrow;
+    if (economy.resources.gold < 0) {
+      finance.defaulted = true;
+    }
+  }
+}

--- a/server/src/turn/manager.ts
+++ b/server/src/turn/manager.ts
@@ -6,6 +6,7 @@ import { LogisticsManager } from '../logistics/manager';
 import { EnergyManager } from '../energy/manager';
 import { SuitabilityManager } from '../suitability/manager';
 import { DevelopmentManager } from '../development/manager';
+import { FinanceManager } from '../finance/manager';
 
 /**
  * Orchestrates the two-phase turn resolution with a one-turn lag.
@@ -136,7 +137,7 @@ export class TurnManager {
   }
 
   private static resolveFinance(_gameState: GameState): void {
-    // TODO: Run the treasury waterfall and debt mechanics.
+    FinanceManager.run(_gameState.economy, { revenues: 0, expenditures: 0 });
   }
 
   private static resolveDevelopment(gameState: GameState): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -270,6 +270,19 @@ export interface ProjectsState {
   projects: ProjectData[];
 }
 
+export interface FinanceState {
+  /** Total outstanding borrowed Gold */
+  debt: number;
+  /** Maximum allowable debt before default */
+  creditLimit: number;
+  /** Interest rate applied to debt each turn */
+  interestRate: number;
+  /** Flag when credit limit exceeded */
+  defaulted: boolean;
+  /** Debt stress tier flags */
+  debtStress: boolean[];
+}
+
 export interface EconomyState {
   resources: Resources;
   cantons: { [cantonId: string]: CantonEconomy };
@@ -287,6 +300,8 @@ export interface EconomyState {
   infrastructure: InfrastructureRegistry;
   /** Capital projects state */
   projects: ProjectsState;
+  /** Treasury, debt, and related finance tracking */
+  finance: FinanceState;
 }
 
 export interface RetoolOrder {

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,3 +74,14 @@ This prints coverage statistics and writes an `lcov.info` report to the `coverag
 - Plants that are idle or under construction produce no energy.
 - Idle economic slots consume no energy.
 
+### Finance System
+- Treasury carries over each turn and updates with revenues and expenditures.
+- Treasury deficits trigger automatic borrowing up to the Credit Limit.
+- Borrowing immediately increases Debt.
+- Interest ticks add to both expenditures and Debt.
+- Default flag raised if Debt exceeds the Credit Limit.
+- Debt Stress tier flags record when thresholds are crossed.
+- Finance resolves after trade but before development.
+- Resolution is deterministic for identical inputs.
+- Tests cover surplus, deficit, interest, credit limit breach, and each stress tier.
+


### PR DESCRIPTION
## Summary
- implement FinanceManager for treasury accounting, auto-borrowing, interest, credit limits, and debt stress tiers
- integrate finance resolution into the turn sequence and expand types/economy state
- add comprehensive tests and documentation for finance system

## Testing
- `bun test`
- `bun run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4b9511f3c8327966a10c1f35d155d