### PR TITLE
Fix autoBorrow debt handling beyond credit limit

### DIFF
--- a/server/src/finance/manager.test.ts
+++ b/server/src/finance/manager.test.ts
@@ -50,11 +50,22 @@ test('borrowing increases debt immediately', () => {
 });
 
 // 5. Credit limit enforcement
- test('exceeding credit limit triggers default', () => {
+test('exceeding credit limit triggers default', () => {
   const eco = createEconomy();
   eco.finance.creditLimit = 100;
   eco.finance.debt = 90;
   FinanceManager.run(eco, { revenues: 0, expenditures: 20 });
+  expect(eco.finance.defaulted).toBeTrue();
+});
+
+// Regression: interest shouldn't reduce debt when over the limit
+test('interest over credit limit accumulates and defaults', () => {
+  const eco = createEconomy();
+  eco.finance.creditLimit = 1000;
+  eco.finance.debt = 995; // interest will push this over the limit
+  eco.finance.interestRate = 0.05;
+  FinanceManager.run(eco, { revenues: 0, expenditures: 0 });
+  expect(Math.round(eco.finance.debt)).toBe(1045);
   expect(eco.finance.defaulted).toBeTrue();
 });
 

--- a/server/src/finance/manager.ts
+++ b/server/src/finance/manager.ts
@@ -45,10 +45,10 @@ export class FinanceManager {
     if (economy.resources.gold >= 0) return;
     const needed = -economy.resources.gold;
     const available = finance.creditLimit - finance.debt;
-    const borrow = Math.min(needed, available);
+    const borrow = Math.max(0, Math.min(needed, available));
     finance.debt += borrow;
     economy.resources.gold += borrow;
-    if (economy.resources.gold < 0) {
+    if (borrow < needed) {
       finance.defaulted = true;
     }
   }


### PR DESCRIPTION
## Summary
- prevent autoBorrow from decreasing debt when no credit remains
- add regression test for interest-induced over-limit debt
- simplify autoBorrow default logic

## Testing
- `bun test`
- `cd server && bun run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4bb173b3c8327b490bb1f0fc396dc