### PR TITLE
feat: add trade and tariffs scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,23 @@ The automated tests verify the following pass criteria:
 5. Handoff tables expose sector slot, labor, and suitability effects by UL.
 6. End-of-turn processing is deterministic for identical inputs.
 7. Tests cover rollover, cap enforcement, UL boundaries, and all decay paths.
+
+## Trade & Tariffs Scaffold
+
+This update adds initial handling for international trade, tariffs, and foreign exchange swaps.
+
+- National gateways (Port, Rail Border, Airport) scale capacity with the capital's Urbanization Level.
+- Gateways consume Logistics Points and levy FX freight costs per unit shipped.
+- Imports pay FX, may incur tariffs that reduce delivered quantity, and arrive the next turn.
+- Exports generate FX immediately and are tariff-free.
+- Insufficient FX automatically scales import orders down.
+- Gold ⇄ FX swaps apply a 10% fee and are capped each turn.
+
+The automated tests verify the following pass criteria:
+
+1. International trade uses only the three gateway types and their capacities scale with UL.
+2. LP and FX freight costs are charged per gateway, sharing the national LP pool with domestic shipping.
+3. Imports pay FX, yield tariff Gold, and deliver reduced quantities next turn while exports earn FX without tariffs.
+4. FX shortfalls auto-scale imports and prevent negative FX balances.
+5. Gold ⇄ FX swaps honour the 10% fee and per-turn cap.
+6. Trade resolution is deterministic for identical inputs.

--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -91,6 +91,7 @@ export class EconomyManager {
         defaulted: false,
         debtStress: [],
       },
+      trade: { pendingImports: {}, pendingExports: {} },
     };
   }
 

--- a/server/src/trade/manager.test.ts
+++ b/server/src/trade/manager.test.ts
@@ -1,0 +1,176 @@
+import { expect, test } from 'bun:test';
+import { EconomyManager } from '../economy/manager';
+import type { EconomyState } from '../types';
+import { TradeManager } from './manager';
+import { GATEWAY_PARAMS } from '../logistics/manager';
+
+function createState(): EconomyState {
+  const state = EconomyManager.createInitialState();
+  EconomyManager.addCanton(state, 'C1');
+  // generous logistics supply by default
+  state.cantons.C1.sectors.logistics = { capacity: 10, funded: 10, idle: 0 } as any;
+  return state;
+}
+
+// Helper for domestic network
+function makeNetwork(connected: boolean, hops: number, capacity: number) {
+  return { connected, hops, capacity_per_turn: capacity };
+}
+
+// 1. Gateways & capacity scaling
+// covers all gateways
+
+test('gateway capacities scale with capital UL', () => {
+  const state = createState();
+  state.resources.fx = 1000;
+  const result = TradeManager.run(state, {
+    capitalUL: 2,
+    lastFinanceOutput: 0,
+    orders: {
+      imports: [
+        { good: 'food', quantity: 50, price: 1, tariff: 0, gateway: 'port' },
+        { good: 'materials', quantity: 50, price: 1, tariff: 0, gateway: 'rail' },
+        { good: 'luxury', quantity: 50, price: 1, tariff: 0, gateway: 'air' },
+      ],
+      exports: [],
+    },
+  });
+  expect(result.logistics.internationalAllocations.port?.units_after_lp_ratio).toBeCloseTo(40);
+  expect(result.logistics.internationalAllocations.rail?.units_after_lp_ratio).toBeCloseTo(30);
+  expect(result.logistics.internationalAllocations.air?.units_after_lp_ratio).toBeCloseTo(20);
+  expect(state.trade.pendingImports.food).toBeCloseTo(40);
+  expect(state.trade.pendingImports.materials).toBeCloseTo(30);
+  expect(state.trade.pendingImports.luxury).toBeCloseTo(20);
+});
+
+// 2. LP usage, freight costs, and shared LP pool with domestic shipping
+
+test('international trade uses same LP pool and records freight FX', () => {
+  const state = createState();
+  state.resources.fx = 1000;
+  // limit logistics supply to 10 LP (1 slot)
+  state.cantons.C1.sectors.logistics = { capacity: 1, funded: 1, idle: 0 } as any;
+  const result = TradeManager.run(state, {
+    capitalUL: 5,
+    lastFinanceOutput: 0,
+    networks: { C1: { rail: makeNetwork(true, 1, 100) } },
+    domesticPlans: { C1: { imports_by_good: { food: 80 }, exports_by_good: {} } },
+    orders: {
+      imports: [
+        { good: 'materials', quantity: 80, price: 1, tariff: 0, gateway: 'port' },
+      ],
+      exports: [],
+    },
+  });
+  const ratio = 10 / (8 + 8); // supply / (domestic + international demand)
+  expect(result.logistics.lp.lp_ratio).toBeCloseTo(ratio);
+  expect(result.logistics.domesticAllocations.C1.rail?.units_after_lp_ratio).toBeCloseTo(80 * ratio);
+  expect(result.logistics.internationalAllocations.port?.units_after_lp_ratio).toBeCloseTo(80 * ratio);
+  const expectedFreight = (80 * ratio) * GATEWAY_PARAMS.port.fxPerUnit;
+  expect(result.freight_fx).toBeCloseTo(expectedFreight);
+  expect(result.logistics.lp.demand_international).toBeCloseTo(80 * GATEWAY_PARAMS.port.costPerHop);
+});
+
+// 3. Tariffs, exports, and next-turn arrivals
+
+test('imports apply tariffs and exports earn FX, arrivals next turn', () => {
+  const state = createState();
+  state.resources.fx = 200;
+  const result = TradeManager.run(state, {
+    capitalUL: 5,
+    lastFinanceOutput: 0,
+    orders: {
+      imports: [
+        { good: 'food', quantity: 10, price: 5, tariff: 0.3, gateway: 'port' },
+        { good: 'materials', quantity: 5, price: 4, tariff: 0, gateway: 'rail' },
+      ],
+      exports: [
+        { good: 'luxury', quantity: 3, price: 10, gateway: 'air' },
+      ],
+    },
+  });
+  // Tariff gold 30% of 10*5 =15
+  expect(result.tariff_gold).toBeCloseTo(15);
+  // FX spent: imports + freight
+  const freight = 10 * GATEWAY_PARAMS.port.fxPerUnit + 5 * GATEWAY_PARAMS.rail.fxPerUnit;
+  expect(result.fx_spent).toBeCloseTo(10 * 5 + 5 * 4 + freight);
+  // FX earned from exports
+  expect(result.fx_earned).toBeCloseTo(3 * 10);
+  // Pending imports reflect tariff friction
+  expect(state.trade.pendingImports.food).toBeCloseTo(10 * (1 - 0.3));
+  expect(state.trade.pendingImports.materials).toBeCloseTo(5);
+  // Goods not yet added
+  expect(state.resources.food).toBe(0);
+  TradeManager.applyPending(state);
+  expect(state.resources.food).toBeCloseTo(10 * (1 - 0.3));
+});
+
+// 4. FX insufficiency auto-scales imports
+
+test('imports auto-scale when FX insufficient', () => {
+  const state = createState();
+  state.resources.fx = 30; // insufficient for 10 units at 5 FX + freight
+  const result = TradeManager.run(state, {
+    capitalUL: 5,
+    lastFinanceOutput: 0,
+    orders: {
+      imports: [
+        { good: 'food', quantity: 10, price: 5, tariff: 0, gateway: 'port' },
+      ],
+      exports: [],
+    },
+  });
+  expect(state.resources.fx).toBeCloseTo(0);
+  const totalCost = 10 * 5 + 10 * GATEWAY_PARAMS.port.fxPerUnit;
+  const ratio = 30 / totalCost;
+  expect(state.trade.pendingImports.food).toBeCloseTo(10 * ratio);
+});
+
+// 5. Swaps enforce cap and fee
+
+test('FX swaps apply fee and cap', () => {
+  const state = createState();
+  state.resources.gold = 100;
+  const result = TradeManager.run(state, {
+    capitalUL: 1,
+    lastFinanceOutput: 30, // cap 60
+    swap: { from: 'gold', amount: 80 },
+    orders: { imports: [], exports: [] },
+  });
+  expect(state.resources.gold).toBeCloseTo(40); // spent 60
+  expect(state.resources.fx).toBeCloseTo(54); // 60 - 6 fee
+  // Now swap back FX->Gold without cap issue
+  state.resources.fx = 100;
+  TradeManager.run(state, {
+    capitalUL: 1,
+    lastFinanceOutput: 100, // cap 200
+    swap: { from: 'fx', amount: 50 },
+    orders: { imports: [], exports: [] },
+  });
+  expect(state.resources.fx).toBeCloseTo(50);
+  expect(state.resources.gold).toBeCloseTo(40 + 45);
+});
+
+// 6. Determinism
+
+test('trade outcomes deterministic for identical inputs', () => {
+  const state1 = createState();
+  state1.resources.fx = 100;
+  const state2: EconomyState = JSON.parse(JSON.stringify(state1));
+  const input = {
+    capitalUL: 3,
+    lastFinanceOutput: 0,
+    orders: {
+      imports: [
+        { good: 'food', quantity: 10, price: 2, tariff: 0.1, gateway: 'port' },
+      ],
+      exports: [],
+    },
+  } as const;
+  const res1 = TradeManager.run(state1, JSON.parse(JSON.stringify(input)));
+  const res2 = TradeManager.run(state2, JSON.parse(JSON.stringify(input)));
+  expect(res1).toEqual(res2);
+  expect(state1.resources).toEqual(state2.resources);
+  expect(state1.trade).toEqual(state2.trade);
+});
+

--- a/server/src/trade/manager.ts
+++ b/server/src/trade/manager.ts
@@ -1,0 +1,201 @@
+// server/src/trade/manager.ts
+import type { EconomyState, ResourceType } from '../types';
+import { LogisticsManager, GATEWAY_PARAMS, type Gateway, type ShippingPlan, type LogisticsResult } from '../logistics/manager';
+
+export interface ImportOrder {
+  good: ResourceType;
+  quantity: number;
+  price: number; // FX per unit
+  tariff: number; // 0-1 fraction
+  gateway: Gateway;
+}
+
+export interface ExportOrder {
+  good: ResourceType;
+  quantity: number;
+  price: number; // FX per unit
+  gateway: Gateway;
+}
+
+export interface TradeOrders {
+  imports?: ImportOrder[];
+  exports?: ExportOrder[];
+}
+
+export interface SwapOrder {
+  from: 'gold' | 'fx';
+  amount: number;
+}
+
+export interface TradeInput {
+  orders: TradeOrders;
+  capitalUL: number;
+  lastFinanceOutput: number;
+  swap?: SwapOrder;
+  networks?: Record<string, any>;
+  domesticPlans?: Record<string, ShippingPlan>;
+}
+
+export interface TradeResult {
+  fx_spent: number;
+  fx_earned: number;
+  tariff_gold: number;
+  freight_fx: number;
+  logistics: LogisticsResult;
+}
+
+interface ImportSettlement {
+  good: ResourceType;
+  qty: number;
+  price: number;
+  tariff: number;
+  gateway: Gateway;
+}
+
+interface ExportSettlement {
+  good: ResourceType;
+  qty: number;
+  price: number;
+  gateway: Gateway;
+}
+
+const GATEWAY_CAPACITY_PER_UL = {
+  port: 20,
+  rail: 15,
+  air: 10,
+} as const;
+
+/**
+ * Scaffolding manager for world market trade, tariffs, and FX swaps.
+ */
+export class TradeManager {
+  static run(state: EconomyState, input: TradeInput): TradeResult {
+    // === Swaps ===
+    if (input.swap) {
+      const cap = 2 * input.lastFinanceOutput;
+      const fromPool = input.swap.from === 'gold' ? state.resources.gold : state.resources.fx;
+      const amount = Math.min(input.swap.amount, cap, fromPool);
+      const fee = amount * 0.1;
+      const net = amount - fee;
+      if (input.swap.from === 'gold') {
+        state.resources.gold -= amount;
+        state.resources.fx += net;
+      } else {
+        state.resources.fx -= amount;
+        state.resources.gold += net;
+      }
+    }
+
+    // === Build logistics plans ===
+    const plans: Partial<Record<Gateway, ShippingPlan>> = {};
+    const importMap: Partial<Record<Gateway, Record<ResourceType, ImportOrder>>> = {};
+    const exportMap: Partial<Record<Gateway, Record<ResourceType, ExportOrder>>> = {};
+
+    for (const order of input.orders.imports ?? []) {
+      const plan = (plans[order.gateway] ||= { imports_by_good: {}, exports_by_good: {} });
+      plan.imports_by_good[order.good] = (plan.imports_by_good[order.good] || 0) + order.quantity;
+      (importMap[order.gateway] ||= {})[order.good] = order;
+    }
+    for (const order of input.orders.exports ?? []) {
+      const plan = (plans[order.gateway] ||= { imports_by_good: {}, exports_by_good: {} });
+      plan.exports_by_good[order.good] = (plan.exports_by_good[order.good] || 0) + order.quantity;
+      (exportMap[order.gateway] ||= {})[order.good] = order;
+    }
+
+    const capacities: Partial<Record<Gateway, number>> = {
+      port: input.capitalUL * GATEWAY_CAPACITY_PER_UL.port,
+      rail: input.capitalUL * GATEWAY_CAPACITY_PER_UL.rail,
+      air: input.capitalUL * GATEWAY_CAPACITY_PER_UL.air,
+    };
+
+    const logistics = LogisticsManager.run(state, {
+      networks: input.networks ?? {},
+      domesticPlans: input.domesticPlans ?? {},
+      internationalPlans: plans,
+      gatewayCapacities: capacities,
+    });
+
+    const imports: ImportSettlement[] = [];
+    const exports: ExportSettlement[] = [];
+    let freight_fx = 0;
+
+    for (const [gateway, alloc] of Object.entries(logistics.internationalAllocations)) {
+      const g = gateway as Gateway;
+      const params = GATEWAY_PARAMS[g];
+      const importOrders = importMap[g] || {};
+      const exportOrders = exportMap[g] || {};
+      let gatewayImportQty = 0;
+      if (alloc.imports) {
+        for (const [good, gAlloc] of Object.entries(alloc.imports)) {
+          const qty = gAlloc.after_lp_ratio;
+          if (qty <= 0) continue;
+          const order = importOrders[good as ResourceType];
+          if (!order) continue;
+          imports.push({ good: good as ResourceType, qty, price: order.price, tariff: order.tariff, gateway: g });
+          gatewayImportQty += qty;
+        }
+      }
+      if (alloc.exports) {
+        for (const [good, gAlloc] of Object.entries(alloc.exports)) {
+          const qty = gAlloc.after_lp_ratio;
+          if (qty <= 0) continue;
+          const order = exportOrders[good as ResourceType];
+          if (!order) continue;
+          exports.push({ good: good as ResourceType, qty, price: order.price, gateway: g });
+        }
+      }
+      freight_fx += gatewayImportQty * params.fxPerUnit;
+    }
+
+    // === FX payment for imports with auto-scaling ===
+    const totalImportValue = imports.reduce((s, i) => s + i.qty * i.price, 0);
+    let totalCost = totalImportValue + freight_fx;
+    let ratio = 1;
+    if (totalCost > 0 && state.resources.fx < totalCost) {
+      ratio = state.resources.fx / totalCost;
+      totalCost = state.resources.fx;
+    }
+    // Apply ratio to imports and freight
+    for (const imp of imports) imp.qty *= ratio;
+    freight_fx *= ratio;
+
+    state.resources.fx -= totalCost;
+    let fx_spent = totalCost;
+    let tariff_gold = 0;
+    for (const imp of imports) {
+      const value = imp.qty * imp.price;
+      const tariff = value * imp.tariff;
+      tariff_gold += tariff;
+      state.trade.pendingImports[imp.good] =
+        (state.trade.pendingImports[imp.good] || 0) + imp.qty * (1 - imp.tariff);
+    }
+    state.resources.gold += tariff_gold;
+
+    // === Exports ===
+    let fx_earned = 0;
+    for (const exp of exports) {
+      const value = exp.qty * exp.price;
+      fx_earned += value;
+    }
+    state.resources.fx += fx_earned;
+
+    return { fx_spent, fx_earned, tariff_gold, freight_fx, logistics };
+  }
+
+  /** Apply pending imports/exports scheduled for this turn. */
+  static applyPending(state: EconomyState): void {
+    for (const [good, qty] of Object.entries(state.trade.pendingImports)) {
+      state.resources[good as ResourceType] += qty;
+    }
+    for (const key of Object.keys(state.trade.pendingImports)) {
+      delete state.trade.pendingImports[key as ResourceType];
+    }
+    for (const [good, qty] of Object.entries(state.trade.pendingExports)) {
+      state.resources[good as ResourceType] += qty; // symmetry placeholder
+    }
+    for (const key of Object.keys(state.trade.pendingExports)) {
+      delete state.trade.pendingExports[key as ResourceType];
+    }
+  }
+}
+

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -283,6 +283,13 @@ export interface FinanceState {
   debtStress: boolean[];
 }
 
+export interface TradeState {
+  /** Imports scheduled to arrive next turn */
+  pendingImports: Partial<Record<ResourceType, number>>;
+  /** Exports scheduled to arrive next turn (for symmetry) */
+  pendingExports: Partial<Record<ResourceType, number>>;
+}
+
 export interface EconomyState {
   resources: Resources;
   cantons: { [cantonId: string]: CantonEconomy };
@@ -302,6 +309,8 @@ export interface EconomyState {
   projects: ProjectsState;
   /** Treasury, debt, and related finance tracking */
   finance: FinanceState;
+  /** Trade state and pending international shipments */
+  trade: TradeState;
 }
 
 export interface RetoolOrder {


### PR DESCRIPTION
## Summary
- scaffold TradeManager handling international orders, tariffs, and FX swaps
- track pending imports/exports in economy state
- document trade & tariffs system and add comprehensive tests

## Testing
- `cd server && bun test`
- `cd server && bun run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4bed7e14483278664975d12dca9b1