### PR TITLE
Implement welfare system scaffolding with policy tiers and costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,25 @@ The automated tests verify the following pass criteria:
 4. FX shortfalls auto-scale imports and prevent negative FX balances.
 5. Gold ⇄ FX swaps honour the 10% fee and per-turn cap.
 6. Trade resolution is deterministic for identical inputs.
+
+## Welfare System Scaffold
+
+This update introduces the Welfare system with adjustable Education and Healthcare policies.
+
+- Policy sliders for Education and Healthcare range from tier 0–4 and may shift only ±1 per turn.
+- Welfare costs are charged per unit of national labor and include Social Support tiers.
+- Selected tiers take effect starting the following production turn.
+- Education shifts the labor mix for new labor, boosts research output, and modifies development rolls.
+- Healthcare modifies happiness per labor and development rolls.
+- Effects from Education and Healthcare stack additively.
+
+The automated tests verify the following pass criteria:
+
+1. Education and Healthcare sliders exist at tiers 0–4 with ±1 change limits.
+2. Policy changes incur a one-turn effect lag.
+3. Welfare cost scales with current national labor and sums Education, Healthcare, and Social Support costs.
+4. Education tiers apply the specified labor mix shifts, research percentages, and development roll modifiers with 2:1 Skilled:Specialist splits capped [0,90].
+5. Healthcare tiers apply the specified happiness and development roll modifiers.
+6. Education and Healthcare modifiers stack additively without double counting.
+7. Identical inputs yield deterministic welfare costs and modifiers.
+8. Tests cover all tiers, step limits, lag behaviour, Social Support costing, and labor mix cap/floor edge cases.

--- a/server/src/economy/manager.ts
+++ b/server/src/economy/manager.ts
@@ -91,6 +91,10 @@ export class EconomyManager {
         defaulted: false,
         debtStress: [],
       },
+      welfare: {
+        current: { education: 0, healthcare: 0, socialSupport: 0 },
+        next: { education: 0, healthcare: 0, socialSupport: 0 },
+      },
       trade: { pendingImports: {}, pendingExports: {} },
     };
   }

--- a/server/src/turn/manager.ts
+++ b/server/src/turn/manager.ts
@@ -7,6 +7,7 @@ import { EnergyManager } from '../energy/manager';
 import { SuitabilityManager } from '../suitability/manager';
 import { DevelopmentManager } from '../development/manager';
 import { FinanceManager } from '../finance/manager';
+import { WelfareManager } from '../welfare/manager';
 
 /**
  * Orchestrates the two-phase turn resolution with a one-turn lag.
@@ -90,11 +91,21 @@ export class TurnManager {
     // TODO: Projects advance, stock and rate updates.
     BudgetManager.advanceRetools(gameState.economy);
     DevelopmentManager.applyPending(gameState.economy);
+    WelfareManager.applyPending(gameState.economy);
   }
 
   private static budgetGate(_gameState: GameState): void {
-    if (!_gameState.currentPlan?.budgets) return;
-    BudgetManager.applyBudgets(_gameState.economy, _gameState.currentPlan.budgets);
+    if (!_gameState.currentPlan) return;
+    const budgets = _gameState.currentPlan.budgets ?? {
+      military: 0,
+      welfare: 0,
+      sectorOM: {},
+    };
+    BudgetManager.applyBudgets(_gameState.economy, budgets);
+    WelfareManager.applyPolicies(
+      _gameState.economy,
+      _gameState.currentPlan.policies?.welfare,
+    );
   }
 
   private static inputsGate(_gameState: GameState): void {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -93,6 +93,19 @@ export interface LaborPool {
   specialist: number;
 }
 
+// Welfare policy tiers for the nation.
+export interface WelfarePolicies {
+  education: number;
+  healthcare: number;
+  socialSupport: number;
+}
+
+// Welfare system state tracking current and next-turn tiers.
+export interface WelfareState {
+  current: WelfarePolicies;
+  next: WelfarePolicies;
+}
+
 // Terrain tile categories that compose a canton geography mix.
 export type TileType =
   | 'plains'
@@ -309,6 +322,8 @@ export interface EconomyState {
   projects: ProjectsState;
   /** Treasury, debt, and related finance tracking */
   finance: FinanceState;
+  /** Welfare policy state */
+  welfare: WelfareState;
   /** Trade state and pending international shipments */
   trade: TradeState;
 }

--- a/server/src/welfare/index.ts
+++ b/server/src/welfare/index.ts
@@ -1,0 +1,1 @@
+export { WelfareManager, EDUCATION_TIERS, HEALTHCARE_TIERS, SOCIAL_SUPPORT_COST } from './manager';

--- a/server/src/welfare/manager.test.ts
+++ b/server/src/welfare/manager.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from 'bun:test';
+import { EconomyManager } from '../economy/manager';
+import { WelfareManager, EDUCATION_TIERS, HEALTHCARE_TIERS, SOCIAL_SUPPORT_COST } from './manager';
+import type { EconomyState, LaborPool } from '../types';
+
+function setupState(labor: LaborPool = { general: 50, skilled: 20, specialist: 10 }): EconomyState {
+  const state = EconomyManager.createInitialState();
+  EconomyManager.addCanton(state, 'A');
+  state.cantons['A'].labor = { ...labor };
+  state.resources.gold = 1000;
+  return state;
+}
+
+// --- Slider and lag behaviour ---
+
+test('sliders clamp to ±1 change per turn', () => {
+  const state = setupState();
+  WelfareManager.applyPolicies(state, { education: 2, healthcare: 2 });
+  expect(state.welfare.next.education).toBe(1);
+  expect(state.welfare.next.healthcare).toBe(1);
+});
+
+test('policy effects apply next turn', () => {
+  const state = setupState();
+  WelfareManager.applyPolicies(state, { education: 1 });
+  // still tier 0 until pending applied
+  expect(state.welfare.current.education).toBe(0);
+  expect(WelfareManager.getModifiers(state).research).toBe(0);
+  WelfareManager.applyPending(state);
+  expect(state.welfare.current.education).toBe(1);
+  expect(WelfareManager.getModifiers(state).research).toBeCloseTo(0.05);
+});
+
+// --- Costing ---
+
+test('welfare cost scales with labor and includes social support', () => {
+  const state = setupState({ general: 40, skilled: 30, specialist: 30 });
+  state.welfare.current = { education: 1, healthcare: 2, socialSupport: 3 };
+  const cost = WelfareManager.applyPolicies(state, {
+    education: 2,
+    healthcare: 3,
+    socialSupport: 4,
+  });
+  const L = 100; // total labor
+  const expected =
+    L *
+    (EDUCATION_TIERS[2].cost +
+      HEALTHCARE_TIERS[3].cost +
+      SOCIAL_SUPPORT_COST[4]);
+  expect(cost).toBeCloseTo(expected);
+  expect(state.resources.gold).toBeCloseTo(1000 - expected);
+});
+
+// --- Education effects ---
+
+test('education tier tables match specification', () => {
+  const laborShifts = [0, 10, 20, 30, 40];
+  const research = [0, 0.05, 0.1, 0.15, 0.2];
+  const dev = [-1, 0, 1, 2, 3];
+  for (let i = 0; i < EDUCATION_TIERS.length; i++) {
+    expect(EDUCATION_TIERS[i].laborShift).toBe(laborShifts[i]);
+    expect(EDUCATION_TIERS[i].research).toBeCloseTo(research[i]);
+    expect(EDUCATION_TIERS[i].devRoll).toBe(dev[i]);
+  }
+});
+
+test('labor mix shift splits 2:1 and caps/floors classes', () => {
+  const base: LaborPool = { general: 100, skilled: 0, specialist: 0 };
+  const shifted = WelfareManager.applyLaborMixShift(base, 10);
+  expect(shifted.general).toBe(90);
+  expect(shifted.skilled + shifted.specialist).toBe(10);
+  const cappedBase: LaborPool = { general: 5, skilled: 88, specialist: 7 };
+  const capped = WelfareManager.applyLaborMixShift(cappedBase, 40);
+  expect(capped.general).toBe(0); // floored
+  expect(capped.skilled).toBe(90); // capped
+});
+
+// --- Healthcare effects ---
+
+test('healthcare tier tables match specification', () => {
+  const happiness = [-1, -0.5, 0, 0.5, 1];
+  const dev = [-1, 0, 1, 1, 2];
+  for (let i = 0; i < HEALTHCARE_TIERS.length; i++) {
+    expect(HEALTHCARE_TIERS[i].happiness).toBe(happiness[i]);
+    expect(HEALTHCARE_TIERS[i].devRoll).toBe(dev[i]);
+  }
+});
+
+// --- Stacking & determinism ---
+
+test('education and healthcare modifiers stack additively', () => {
+  const state = setupState();
+  state.welfare.current = { education: 2, healthcare: 3, socialSupport: 0 };
+  const mods = WelfareManager.getModifiers(state);
+  expect(mods.devRoll).toBe(EDUCATION_TIERS[2].devRoll + HEALTHCARE_TIERS[3].devRoll);
+  expect(mods.research).toBeCloseTo(EDUCATION_TIERS[2].research);
+  expect(mods.happinessPerLabor).toBeCloseTo(HEALTHCARE_TIERS[3].happiness);
+});
+
+test('identical inputs yield identical cost and modifiers', () => {
+  const s1 = setupState();
+  const s2 = setupState();
+  const policies = { education: 1, healthcare: 2, socialSupport: 1 };
+  const c1 = WelfareManager.applyPolicies(s1, policies);
+  const c2 = WelfareManager.applyPolicies(s2, policies);
+  expect(c1).toBe(c2);
+  WelfareManager.applyPending(s1);
+  WelfareManager.applyPending(s2);
+  const m1 = WelfareManager.getModifiers(s1);
+  const m2 = WelfareManager.getModifiers(s2);
+  expect(m1).toEqual(m2);
+});

--- a/server/src/welfare/manager.ts
+++ b/server/src/welfare/manager.ts
@@ -1,0 +1,110 @@
+import type { EconomyState, LaborPool, WelfarePolicies } from '../types';
+
+export interface EducationTier {
+  cost: number;
+  laborShift: number;
+  research: number;
+  devRoll: number;
+}
+
+export interface HealthcareTier {
+  cost: number;
+  happiness: number;
+  devRoll: number;
+}
+
+export const EDUCATION_TIERS: EducationTier[] = [
+  { cost: 0,    laborShift: 0,  research: 0,    devRoll: -1 },
+  { cost: 0.25, laborShift: 10, research: 0.05, devRoll: 0 },
+  { cost: 0.5,  laborShift: 20, research: 0.10, devRoll: 1 },
+  { cost: 0.75, laborShift: 30, research: 0.15, devRoll: 2 },
+  { cost: 1,    laborShift: 40, research: 0.20, devRoll: 3 },
+];
+
+export const HEALTHCARE_TIERS: HealthcareTier[] = [
+  { cost: 0,    happiness: -1,  devRoll: -1 },
+  { cost: 0.25, happiness: -0.5, devRoll: 0 },
+  { cost: 0.5,  happiness: 0,    devRoll: 1 },
+  { cost: 0.75, happiness: 0.5,  devRoll: 1 },
+  { cost: 1,    happiness: 1,    devRoll: 2 },
+];
+
+export const SOCIAL_SUPPORT_COST: number[] = [0, 0.25, 0.5, 0.75, 1];
+
+function clampTier(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(4, Math.round(value)));
+}
+
+/**
+ * Total national labor across all cantons.
+ */
+export function totalLabor(state: EconomyState): number {
+  let total = 0;
+  for (const canton of Object.values(state.cantons)) {
+    const l = canton.labor;
+    total += l.general + l.skilled + l.specialist;
+  }
+  return total;
+}
+
+export class WelfareManager {
+  /** Apply policy sliders for this turn and charge welfare cost. */
+  static applyPolicies(
+    state: EconomyState,
+    policies?: Partial<WelfarePolicies>,
+  ): number {
+    const current = state.welfare.current;
+    const next = { ...current };
+
+    if (policies) {
+      for (const key of ['education', 'healthcare', 'socialSupport'] as const) {
+        const desired = policies[key];
+        if (typeof desired === 'number') {
+          const clamped = clampTier(desired);
+          const limited = Math.max(current[key] - 1, Math.min(current[key] + 1, clamped));
+          next[key] = limited;
+        }
+      }
+    }
+
+    state.welfare.next = next;
+
+    const L = totalLabor(state);
+    const cost =
+      L *
+      (EDUCATION_TIERS[next.education].cost +
+        HEALTHCARE_TIERS[next.healthcare].cost +
+        SOCIAL_SUPPORT_COST[next.socialSupport]);
+
+    state.resources.gold -= cost;
+    return cost;
+  }
+
+  /** Move next-turn tiers into current active tiers. */
+  static applyPending(state: EconomyState): void {
+    state.welfare.current = { ...state.welfare.next };
+  }
+
+  /** Get combined welfare modifiers from active tiers. */
+  static getModifiers(state: EconomyState) {
+    const edu = EDUCATION_TIERS[state.welfare.current.education];
+    const health = HEALTHCARE_TIERS[state.welfare.current.healthcare];
+    return {
+      laborShift: edu.laborShift,
+      research: edu.research,
+      devRoll: edu.devRoll + health.devRoll,
+      happinessPerLabor: health.happiness,
+    };
+  }
+
+  /** Apply an education labor mix shift to a labor pool (percentages). */
+  static applyLaborMixShift(labor: LaborPool, points: number): LaborPool {
+    const skilledAdd = Math.round((points * 2) / 3);
+    const specialistAdd = points - skilledAdd;
+    const general = Math.max(0, labor.general - points);
+    const skilled = Math.min(90, labor.skilled + skilledAdd);
+    const specialist = Math.min(90, labor.specialist + specialistAdd);
+    return { general, skilled, specialist };
+  }
+}


### PR DESCRIPTION
## Summary
- Add welfare manager with Education, Healthcare, and Social Support tiers, costs, and effects
- Track current and next welfare policies with ±1 tier change limits and one-turn lag
- Integrate welfare cost and policy application into turn budget gate
- Provide hooks for labor mix shifts, research, happiness, and development modifiers
- Document welfare system and add comprehensive tests

## Testing
- `bun test`
- `bun run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4c3306a7883279c62373c098db271