### PR TITLE
Implement core turn sequencing and add turn flow tests

### DIFF
--- a/server/src/turn/manager.test.ts
+++ b/server/src/turn/manager.test.ts
@@ -2,6 +2,7 @@ import { expect, test, spyOn } from 'bun:test';
 import { TurnManager } from './manager';
 import { BudgetManager } from '../budget/manager';
 import { EconomyManager } from '../economy/manager';
+import { DevelopmentManager } from '../development/manager';
 import type { GameState, TurnPlan } from '../types';
 
 function createGameState(currentPlan: TurnPlan | null, nextPlan: TurnPlan | null): GameState {
@@ -52,19 +53,30 @@ test('per-turn sequence invokes gates in order', () => {
     ['logisticsGate', TurnManager],
     ['laborGate', TurnManager],
     ['suitabilityGate', TurnManager],
+    ['multiplySiteFactors', TurnManager],
+    ['resolveOutputAndConsumption', TurnManager],
+    ['resolveTradeAndFX', TurnManager],
+    ['resolveFinance', TurnManager],
+    ['resolveDevelopment', TurnManager],
     ['cleanup', TurnManager],
   ];
 
   const originals: Record<string, any> = {};
   for (const [method] of patches) {
     originals[method] = (TurnManager as any)[method];
-    (TurnManager as any)[method] = (gs: GameState) => {
+    (TurnManager as any)[method] = (...args: any[]) => {
       order.push(method);
-      return originals[method].call(TurnManager, gs);
+      return originals[method].apply(TurnManager, args);
     };
   }
 
-  TurnManager.advanceTurn(state);
+  try {
+    TurnManager.advanceTurn(state);
+  } finally {
+    for (const [method] of patches) {
+      (TurnManager as any)[method] = originals[method];
+    }
+  }
 
   expect(order).toEqual([
     'carryover',
@@ -73,12 +85,13 @@ test('per-turn sequence invokes gates in order', () => {
     'logisticsGate',
     'laborGate',
     'suitabilityGate',
+    'multiplySiteFactors',
+    'resolveOutputAndConsumption',
+    'resolveTradeAndFX',
+    'resolveFinance',
+    'resolveDevelopment',
     'cleanup',
   ]);
-
-  for (const [method] of patches) {
-    (TurnManager as any)[method] = originals[method];
-  }
 });
 
 test('planning writes to next-turn buffer', () => {
@@ -102,4 +115,93 @@ test('cleanup creates turn summary artifact', () => {
   expect((state as any).turnSummary).toBeDefined();
 
   (TurnManager as any).cleanup = original;
+});
+
+test('budget prioritizes suitability and charges idle cost', () => {
+  const plan: TurnPlan = {
+    budgets: {
+      military: 0,
+      welfare: 0,
+      sectorOM: { agriculture: 5, logistics: 1 },
+    },
+  };
+  const state = createGameState(plan, null);
+  const econ = state.economy;
+  EconomyManager.addCanton(econ, 'A');
+  EconomyManager.addCanton(econ, 'B');
+  econ.cantons.A.sectors.agriculture = { capacity: 5, funded: 0, idle: 0 } as any;
+  econ.cantons.B.sectors.agriculture = { capacity: 5, funded: 0, idle: 0 } as any;
+  econ.cantons.A.suitability.agriculture = 10;
+  econ.cantons.B.suitability.agriculture = 0;
+  econ.cantons.A.urbanizationLevel = 2;
+  econ.cantons.A.sectors.logistics = { capacity: 1, funded: 0, idle: 0 } as any;
+  econ.cantons.A.suitability.logistics = 0;
+  econ.energy.plants.push({ canton: 'A', type: 'coal', status: 'active' } as any);
+
+  TurnManager.advanceTurn(state);
+  expect(econ.cantons.A.sectors.agriculture.funded).toBe(3);
+  expect(econ.cantons.B.sectors.agriculture.funded).toBe(2);
+  // Total cost 7.25 plus interest causes debt ~7.975
+  expect(econ.finance.debt).toBeCloseTo(7.975);
+});
+
+test('energy and logistics shortfalls scale funded slots', () => {
+  const plan: TurnPlan = {
+    budgets: {
+      military: 0,
+      welfare: 0,
+      sectorOM: { agriculture: 10, logistics: 0 },
+    },
+  };
+  const state = createGameState(plan, null);
+  const econ = state.economy;
+  EconomyManager.addCanton(econ, 'A');
+  econ.cantons.A.sectors.agriculture = { capacity: 10, funded: 0, idle: 0 } as any;
+  econ.cantons.A.suitability.agriculture = 0;
+  econ.cantons.A.urbanizationLevel = 3;
+  // energy plant only produces 5 units -> ratio 0.5
+  econ.energy.plants.push({ canton: 'A', type: 'oilPeaker', status: 'active' } as any);
+  // logistics supply 0 -> all slots idle after logistics gate
+  TurnManager.advanceTurn(state);
+  // energy gate halves funded to 5 before logistics zeroes it
+  expect(econ.energy.state.ratio).toBeCloseTo(0.5);
+  expect(econ.cantons.A.sectors.agriculture.funded).toBe(0);
+});
+
+test('retool completion and UL change apply next turn', () => {
+  const plan1: TurnPlan = { budgets: { military: 0, welfare: 0, sectorOM: {} } };
+  const plan2: TurnPlan = {
+    budgets: { military: 0, welfare: 0, sectorOM: { manufacturing: 1 } },
+  };
+  const state = createGameState(plan1, plan2);
+  const econ = state.economy;
+  EconomyManager.addCanton(econ, 'A');
+  econ.cantons.A.sectors.manufacturing = { capacity: 0, funded: 0, idle: 0 } as any;
+  econ.cantons.A.suitability.manufacturing = 0;
+  econ.cantons.A.urbanizationLevel = 1;
+  // pending retool that finishes after first turn
+  econ.retoolQueue.push({
+    canton: 'A',
+    sector_from: 'agriculture',
+    sector_to: 'manufacturing',
+    slots: 1,
+    turns_remaining: 1,
+  } as any);
+  // force development roll to increase UL next turn
+  const originalDev = (TurnManager as any).resolveDevelopment;
+  (TurnManager as any).resolveDevelopment = (gs: GameState) => {
+    const inputs = { A: { baseRoll: 4 } } as any;
+    DevelopmentManager.run(gs.economy, inputs);
+  };
+
+  TurnManager.advanceTurn(state);
+  // new slot not yet usable and UL not yet applied
+  expect(econ.cantons.A.sectors.manufacturing.capacity).toBe(1);
+  expect(econ.cantons.A.urbanizationLevel).toBe(1);
+  expect(econ.cantons.A.nextUrbanizationLevel).toBe(2);
+
+  (TurnManager as any).resolveDevelopment = originalDev;
+  TurnManager.advanceTurn(state);
+  // capacity usable and UL applied
+  expect(econ.cantons.A.urbanizationLevel).toBe(2);
 });


### PR DESCRIPTION
## Summary
- implement full turn progression with one-turn lag and gate sequencing
- scale sectors by energy, logistics, and labor; resolve outputs, trade, finance, and development
- add comprehensive turn manager tests for sequencing, budget prioritization, resource shortfalls, and lagged effects

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4d419bdec8327afe7ec5929841787