### PR TITLE
Implement gateway hop costs and trade edge case tests

### DIFF
--- a/server/src/trade/manager.ts
+++ b/server/src/trade/manager.ts
@@ -34,6 +34,7 @@ export interface TradeInput {
   swap?: SwapOrder;
   networks?: Record<string, any>;
   domesticPlans?: Record<string, ShippingPlan>;
+  gatewayHops?: Partial<Record<Gateway, number>>;
 }
 
 export interface TradeResult {
@@ -113,6 +114,7 @@ export class TradeManager {
       domesticPlans: input.domesticPlans ?? {},
       internationalPlans: plans,
       gatewayCapacities: capacities,
+      gatewayHops: input.gatewayHops,
     });
 
     const imports: ImportSettlement[] = [];


### PR DESCRIPTION
## Summary
- Support explicit hop counts for international gateways and scale LP demand accordingly
- Forward gateway hop data through trade manager for world-market orders
- Add edge case tests for zero FX imports and hop-driven LP demand

## Testing
- `bun test`
- `bun test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68b4f7c2bdf4832781cf1ca65bdf92eb