### PR TITLE
Seed nations with initial infrastructure

### DIFF
--- a/server/src/game-state/manager.ts
+++ b/server/src/game-state/manager.ts
@@ -9,7 +9,8 @@ import type {
   EntityId,
   Entity,
   EntityType,
-  MapSize
+  MapSize,
+  InfrastructureData
 } from '../types';
 import { EconomyManager } from '../economy';
 
@@ -332,6 +333,59 @@ export class GameStateManager {
           this.claimCell(gameState, neighbor, owner);
           claimable.delete(neighbor);
         }
+      }
+    }
+  }
+
+  static initializeNationInfrastructure(
+    gameState: GameState,
+    players: PlayerId[],
+    biomes: Uint8Array,
+    cellNeighbors: Int32Array,
+    cellOffsets: Uint32Array,
+  ): void {
+    const SHALLOW_OCEAN = 6;
+    const DEEP_OCEAN = 7;
+
+    for (const player of players) {
+      const cells = this.getPlayerCells(gameState, player);
+      if (cells.length === 0) continue;
+      const capital = cells[0];
+      const cantonId = String(capital);
+
+      // Ensure a canton exists for this capital cell
+      EconomyManager.addCanton(gameState.economy, cantonId);
+
+      const base: InfrastructureData = {
+        owner: 'national',
+        status: 'active',
+        national: true,
+        hp: 100,
+      };
+
+      // National Airport and Rail Hub
+      gameState.economy.infrastructure.airports[cantonId] = { ...base };
+      gameState.economy.infrastructure.railHubs[cantonId] = { ...base };
+      gameState.economy.infrastructure.national.airport = cantonId;
+      gameState.economy.infrastructure.national.rail = cantonId;
+
+      // Check if the capital cell is coastal for port placement
+      let coastal = false;
+      const start = cellOffsets[capital];
+      const end = cellOffsets[capital + 1];
+      for (let i = start; i < end; i++) {
+        const nb = cellNeighbors[i];
+        if (nb < 0) continue;
+        const biome = biomes[nb];
+        if (biome === SHALLOW_OCEAN || biome === DEEP_OCEAN) {
+          coastal = true;
+          break;
+        }
+      }
+
+      if (coastal) {
+        gameState.economy.infrastructure.ports[cantonId] = { ...base };
+        gameState.economy.infrastructure.national.port = cantonId;
       }
     }
   }

--- a/server/src/game-state/service.ts
+++ b/server/src/game-state/service.ts
@@ -246,7 +246,15 @@ export class GameService {
         meshData.cellCount,
         game.map.biomes
       );
-      
+
+      GameStateManager.initializeNationInfrastructure(
+        game.state,
+        game.meta.players,
+        game.map.biomes,
+        meshData.cellNeighbors,
+        meshData.cellOffsets,
+      );
+
       // Persist updated state
       await this.saveGame(game);
 


### PR DESCRIPTION
## Summary
- Ensure each nation begins with a capital canton hosting national airport and rail hub
- Add coastal detection and spawn national port when possible
- Initialize nations' infrastructure during game start

## Testing
- `cd server && bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b5273b7b048327b3ce16a0d662fed2