### PR TITLE
Hide terrain controls after game creation

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,4 +1,4 @@
-import { createUI } from './ui';
+import { createUI, hideTerrainControls } from './ui';
 import {
   loadOrGetMesh,
   preloadMeshes,
@@ -73,6 +73,7 @@ function toggleGameButtons(visible: boolean) {
 // Creator's game state UI (world generated immediately)
 function showCreatorGameUI(gameData: any) {
   hideAllGameUI();
+  hideTerrainControls();
   
   const gameStateDiv = createGameStateContainer();
   
@@ -151,6 +152,7 @@ function showCreatorGameUI(gameData: any) {
 // Joiner's game state UI (no Start Game button)
 function showJoinerGameUI(gameData: any) {
   hideAllGameUI();
+  hideTerrainControls();
   
   const gameStateDiv = createGameStateContainer();
   

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -4,6 +4,7 @@ import { loadOrGetMesh, generateTerrain, elevationConfig, biomeConfig, setCurren
 export function createUI(ctx: CanvasRenderingContext2D) {
   // Create UI panel
   const uiPanel = document.createElement("div");
+  uiPanel.id = "biomeControls";
   uiPanel.style.cssText = `
     position: fixed;
     top: 10px;
@@ -301,5 +302,12 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         generateTerrain(ctx);
       });
     }
+  }
+}
+
+export function hideTerrainControls() {
+  const panel = document.getElementById('biomeControls');
+  if (panel) {
+    (panel as HTMLElement).style.display = 'none';
   }
 }


### PR DESCRIPTION
## Summary
- Hide biome terrain controls once a game is created or joined
- Provide utility to remove terrain controls panel

## Testing
- `bun test server tests`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68bbbd9449b88327a3a2789eabb8275f