### PR TITLE
Hide terrain controls after game creation

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,4 +1,4 @@
-import { createUI } from './ui';
+import { createUI, hideTerrainControls } from './ui';
 import {
   loadOrGetMesh,
   preloadMeshes,
@@ -73,7 +73,8 @@ function toggleGameButtons(visible: boolean) {
 // Creator's game state UI (world generated immediately)
 function showCreatorGameUI(gameData: any) {
   hideAllGameUI();
-  
+  hideTerrainControls();
+
   const gameStateDiv = createGameStateContainer();
   
   gameStateDiv.innerHTML = `
@@ -151,7 +152,8 @@ function showCreatorGameUI(gameData: any) {
 // Joiner's game state UI (no Start Game button)
 function showJoinerGameUI(gameData: any) {
   hideAllGameUI();
-  
+  hideTerrainControls();
+
   const gameStateDiv = createGameStateContainer();
   
   gameStateDiv.innerHTML = `
@@ -365,23 +367,14 @@ function hideAllGameUI() {
 }
 
 function createGameStateContainer() {
-  let gameStateDiv = document.getElementById("gameState");
-  
-  if (!gameStateDiv) {
-    gameStateDiv = document.createElement("div");
-    gameStateDiv.id = "gameState";
-    gameStateDiv.style.cssText = `
+  const gameStateDiv = document.getElementById("gameState")!;
+  gameStateDiv.style.cssText = `
       margin-top: 15px;
       padding: 15px;
       background: rgba(0, 100, 0, 0.2);
       border: 1px solid #4CAF50;
       border-radius: 8px;
     `;
-    
-    const buttonsDiv = document.querySelector('#createGame')!.parentElement;
-    buttonsDiv!.parentNode!.insertBefore(gameStateDiv, buttonsDiv!.nextSibling);
-  }
-  
   gameStateDiv.style.display = "block";
   return gameStateDiv;
 }

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -21,6 +21,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
   `;
 
   uiPanel.innerHTML = `
+    <div id="terrainControls">
     <h3 style="margin: 0 0 15px 0; color: #4CAF50;">Biome Terrain Controls</h3>
 
     <div style="margin-bottom: 15px;">
@@ -194,6 +195,8 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         <button id="joinGame" style="flex: 1; background: #2196F3; color: white; border: none; padding: 10px; border-radius: 4px; cursor: pointer;">Join Game</button>
       </div>
     </div>
+    </div>
+    <div id="gameState" style="display: none;"></div>
   `;
 
   document.body.appendChild(uiPanel);
@@ -302,4 +305,9 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       });
     }
   }
+}
+
+export function hideTerrainControls() {
+  const controls = document.getElementById('terrainControls');
+  if (controls) controls.style.display = 'none';
 }


### PR DESCRIPTION
## Summary
- Wrap terrain configuration UI in a dedicated container and add persistent gameState slot outside it
- Hide all terrain controls after creating or joining a game while preserving the gameState panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc05dbda0832786a851ce5068a961