### PR TITLE
Add game controls section with Nation Planner

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -361,9 +361,11 @@ async function handleJoinGameSubmit() {
 function hideAllGameUI() {
   const gameStateDiv = document.getElementById("gameState");
   const joinFormDiv = document.getElementById("joinGameForm");
-  
+  const gameControlsDiv = document.getElementById("gameControls");
+
   if (gameStateDiv) gameStateDiv.style.display = "none";
   if (joinFormDiv) joinFormDiv.style.display = "none";
+  if (gameControlsDiv) gameControlsDiv.style.display = "none";
 }
 
 function createGameStateContainer() {
@@ -518,24 +520,30 @@ export function handleFullGame(gameData: any) {
 // Update game status display
 function updateGameStatus(status: string) {
   const statusElement = document.getElementById('gameStatus');
-  if (!statusElement) return;
-  
-  switch (status) {
-    case 'waiting':
-      statusElement.textContent = 'Waiting for players...';
-      statusElement.style.color = '#FFA500';
-      break;
-    case 'in_progress':
-      statusElement.textContent = 'Game in progress';
-      statusElement.style.color = '#4CAF50';
-      break;
-    case 'finished':
-      statusElement.textContent = 'Game finished';
-      statusElement.style.color = '#666';
-      break;
-    default:
-      statusElement.textContent = status;
-      statusElement.style.color = '#FFA500';
+  const gameControls = document.getElementById('gameControls');
+
+  if (statusElement) {
+    switch (status) {
+      case 'waiting':
+        statusElement.textContent = 'Waiting for players...';
+        statusElement.style.color = '#FFA500';
+        break;
+      case 'in_progress':
+        statusElement.textContent = 'Game in progress';
+        statusElement.style.color = '#4CAF50';
+        break;
+      case 'finished':
+        statusElement.textContent = 'Game finished';
+        statusElement.style.color = '#666';
+        break;
+      default:
+        statusElement.textContent = status;
+        statusElement.style.color = '#FFA500';
+    }
+  }
+
+  if (gameControls) {
+    gameControls.style.display = status === 'in_progress' ? 'block' : 'none';
   }
 }
 

--- a/client/src/ui.spec.ts
+++ b/client/src/ui.spec.ts
@@ -13,4 +13,16 @@ const runInVitest = typeof (globalThis as any).Bun === 'undefined';
     const panel = document.body.querySelector('div');
     expect(panel).not.toBeNull();
   });
+
+  it('includes budget controls in the nation planner', () => {
+    createUI({} as CanvasRenderingContext2D);
+
+    const planner = document.getElementById('nationPlanner');
+    expect(planner).not.toBeNull();
+
+    ['military', 'welfare', 'sectorOps', 'maintenance'].forEach(type => {
+      expect(document.getElementById(`${type}Budget`)).not.toBeNull();
+      expect(document.getElementById(`${type}BudgetInfo`)).not.toBeNull();
+    });
+  });
 });

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -197,6 +197,11 @@ export function createUI(ctx: CanvasRenderingContext2D) {
     </div>
     </div>
     <div id="gameState" style="display: none;"></div>
+    <div id="gameControls" style="display: none;">
+      <details id="nationPlanner">
+        <summary>Nation Planner</summary>
+      </details>
+    </div>
   `;
 
   document.body.appendChild(uiPanel);

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -200,6 +200,36 @@ export function createUI(ctx: CanvasRenderingContext2D) {
     <div id="gameControls" style="display: none;">
       <details id="nationPlanner">
         <summary>Nation Planner</summary>
+        <div id="budgetControls" style="margin-top: 10px;">
+          <div style="margin-bottom: 8px;">
+            <label>
+              Military Budget: 
+              <input type="number" id="militaryBudget" min="0" value="0" style="width: 60px; margin-left: 5px;">
+              <span id="militaryBudgetInfo" style="margin-left: 5px;">$0</span>
+            </label>
+          </div>
+          <div style="margin-bottom: 8px;">
+            <label>
+              Welfare Budget: 
+              <input type="number" id="welfareBudget" min="0" value="0" style="width: 60px; margin-left: 5px;">
+              <span id="welfareBudgetInfo" style="margin-left: 5px;">$0</span>
+            </label>
+          </div>
+          <div style="margin-bottom: 8px;">
+            <label>
+              Sector Operations Budget: 
+              <input type="number" id="sectorOpsBudget" min="0" value="0" style="width: 60px; margin-left: 5px;">
+              <span id="sectorOpsBudgetInfo" style="margin-left: 5px;">$0</span>
+            </label>
+          </div>
+          <div style="margin-bottom: 8px;">
+            <label>
+              Maintenance Budget: 
+              <input type="number" id="maintenanceBudget" min="0" value="0" style="width: 60px; margin-left: 5px;">
+              <span id="maintenanceBudgetInfo" style="margin-left: 5px;">$0</span>
+            </label>
+          </div>
+        </div>
       </details>
     </div>
   `;
@@ -228,6 +258,24 @@ export function createUI(ctx: CanvasRenderingContext2D) {
     if (!isNaN(value)) {
       elevationConfig.seed = Math.max(0, Math.min(1, value));
       generateTerrain(ctx);
+    }
+  });
+
+  // Budget input handlers
+  [
+    'military',
+    'welfare',
+    'sectorOps',
+    'maintenance'
+  ].forEach((type) => {
+    const input = document.getElementById(`${type}Budget`) as HTMLInputElement | null;
+    const info = document.getElementById(`${type}BudgetInfo`);
+    if (input && info) {
+      const updateInfo = () => {
+        info.textContent = `$${input.value}`;
+      };
+      input.addEventListener('input', updateInfo);
+      updateInfo();
     }
   });
 


### PR DESCRIPTION
## Summary
- add gameControls container with Nation Planner details
- toggle game controls visibility based on game status

## Testing
- `npm test` *(fails: joining player receives full game data on websocket connect timed out)*
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68bde6f5d5608327bbd4c643e2ea4921