### PR TITLE
feat: add nation planner UI and backend plan API

### DIFF
--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -12,6 +12,7 @@ import {
 } from './terrain';
 import { addToRoom, removeFromRoom, sendGameAction } from './network';
 import { showGameNotification } from './notifications';
+import { showNationPlanner, hideNationPlanner } from './planner';
 
 let canvas: HTMLCanvasElement;
 let ctx: CanvasRenderingContext2D;
@@ -75,6 +76,14 @@ export function handleGameUpdate(data: any): void {
     }
 
     renderGameState();
+
+    if (gameState.status === 'in_progress') {
+      if (currentGameId && currentPlayerName) {
+        showNationPlanner(gameState, currentGameId, currentPlayerName);
+      }
+    } else {
+      hideNationPlanner();
+    }
   }
 }
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -10,6 +10,7 @@ import {
 import { WIDTH, HEIGHT, SERVER_BASE_URL } from './config';
 import { initializeWebSocket, closeWebSocket } from './network';
 import { showGameNotification } from './notifications';
+import { showNationPlanner, hideNationPlanner } from './planner';
 import {
   initGame,
   joinGameRoom,
@@ -512,6 +513,13 @@ export function handleFullGame(gameData: any) {
 
     // Process all the game data received in the WebSocket event
     processGameData(fullGame);
+    if (fullGame.state.status === 'in_progress') {
+      if (currentGameId && currentPlayerName) {
+        showNationPlanner(fullGame.state, currentGameId, currentPlayerName);
+      }
+    } else {
+      hideNationPlanner();
+    }
   }
 }
 

--- a/client/src/network.ts
+++ b/client/src/network.ts
@@ -93,3 +93,21 @@ export function removeFromRoom(gameId: string | null, playerName: string | null)
   if (!gameId || !playerName) return;
   sendWebSocketMessage('remove_from_room', { gameId, playerName });
 }
+export async function fetchPlan(gameId: string) {
+  const res = await fetch(`${SERVER_BASE_URL}/api/games/${gameId}/plan`);
+  if (!res.ok) throw new Error('Failed to fetch plan');
+  return res.json();
+}
+
+export async function submitTurnPlan(gameId: string, playerId: string, plan: any) {
+  const res = await fetch(`${SERVER_BASE_URL}/api/games/${gameId}/plan`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ playerId, plan }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to submit plan');
+  }
+  return res.json();
+}

--- a/client/src/planner.spec.ts
+++ b/client/src/planner.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { showNationPlanner, hideNationPlanner } from './planner';
+
+describe('Nation Planner UI', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="gameControls" style="display:none"></div>';
+    (global as any).fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ budgets:{military:0,welfare:0,sectorOM:{}}, policies:{welfare:{education:0,healthcare:0}}, slotPriorities:{} }) });
+  });
+
+  it('is hidden until shown and can be hidden again', async () => {
+    const state = { economy: { resources:{ gold:100 }, cantons:{} } } as any;
+    await showNationPlanner(state, 'g1', 'p1');
+    const container = document.getElementById('gameControls')!;
+    expect(container.style.display).toBe('block');
+    hideNationPlanner();
+    expect(container.style.display).toBe('none');
+  });
+
+  it('updates warnings for overspend and welfare shortfall', async () => {
+    const state = { economy: { resources:{ gold:100 }, cantons:{ A:{ labor:{general:50,skilled:0,specialist:0}, sectors:{}, suitability:{} } } } } as any;
+    await showNationPlanner(state, 'g1', 'p1');
+    const military = document.getElementById('budget-military') as HTMLInputElement;
+    const welfare = document.getElementById('budget-welfare') as HTMLInputElement;
+    military.value = '80';
+    welfare.value = '30';
+    military.dispatchEvent(new Event('input'));
+    expect((document.getElementById('overspendWarning') as HTMLElement).style.display).toBe('block');
+    (document.getElementById('welfare-edu') as HTMLInputElement).value = '4';
+    (document.getElementById('welfare-health') as HTMLInputElement).value = '4';
+    welfare.value = '50';
+    welfare.dispatchEvent(new Event('input'));
+    expect((document.getElementById('welfareWarning') as HTMLElement).style.display).toBe('block');
+  });
+
+  it('sends plan payload to backend', async () => {
+    const state = { economy: { resources:{ gold:100 }, cantons:{} } } as any;
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok:true, json: async ()=> ({ budgets:{}, policies:{welfare:{education:0,healthcare:0}}, slotPriorities:{} }) })
+      .mockResolvedValue({ ok:true, json: async ()=> ({}) });
+    (global as any).fetch = fetchMock;
+    await showNationPlanner(state, 'g1', 'p1');
+    (document.getElementById('budget-military') as HTMLInputElement).value = '10';
+    (document.getElementById('submitPlan') as HTMLButtonElement).click();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(body.playerId).toBe('p1');
+    expect(body.plan.budgets.military).toBe(10);
+  });
+});

--- a/client/src/planner.ts
+++ b/client/src/planner.ts
@@ -1,0 +1,195 @@
+import { fetchPlan, submitTurnPlan } from './network';
+
+const sectors = ['agriculture','manufacturing','energy'];
+const EDUCATION_COST = [0,0.25,0.5,0.75,1];
+const HEALTHCARE_COST = [0,0.25,0.5,0.75,1];
+
+let currentState: any;
+let gameId: string;
+let playerId: string;
+let availableGold = 0;
+let militaryUpkeep = 0;
+let initialized = false;
+
+export async function showNationPlanner(state:any, gId:string, pId:string) {
+  currentState = state;
+  gameId = gId;
+  playerId = pId;
+  availableGold = state.economy?.resources?.gold || 0;
+  militaryUpkeep = state.economy?.militaryUpkeep || 0;
+  const container = document.getElementById('gameControls');
+  if (!container) return;
+  container.style.display = 'block';
+  if (!initialized || !container.hasChildNodes()) {
+    container.innerHTML = renderPlanner();
+    setupHandlers();
+    initialized = true;
+  }
+  await loadPlan();
+  updateSectorStatus();
+  updateBudgetTotals();
+}
+
+export function hideNationPlanner() {
+  const container = document.getElementById('gameControls');
+  if (container) container.style.display = 'none';
+}
+
+function renderPlanner(): string {
+  return `
+    <details id="nationPlanner">
+      <summary>Nation Planner</summary>
+      <div id="plannerWarnings">
+        <div id="overspendWarning" style="display:none;color:orange;">Overspending Gold</div>
+        <div id="militaryWarning" style="display:none;color:orange;">Military upkeep gap</div>
+        <div id="welfareWarning" style="display:none;color:orange;">Welfare tiers will auto-reduce</div>
+      </div>
+      <section id="plannerBudgets">
+        <h4>Budgets</h4>
+        <div>Gold Allocated: <span id="goldAllocated">0</span> / <span id="goldAvailable"></span></div>
+        <label>Military: <input type="number" id="budget-military" min="0" value="0"></label>
+        <label>Welfare: <input type="number" id="budget-welfare" min="0" value="0"></label>
+        <label>Education Tier: <input type="number" id="welfare-edu" min="0" max="4" value="0"></label>
+        <label>Healthcare Tier: <input type="number" id="welfare-health" min="0" max="4" value="0"></label>
+        <div id="sectorBudgets">
+          ${sectors.map(s=>`<div><label>${capitalize(s)}: <input type="number" id="sector-${s}" min="0" value="0"></label></div>`).join('')}
+        </div>
+      </section>
+      <section id="plannerPriorities">
+        <h4>Sector Prioritization</h4>
+        <ul id="sectorList" style="list-style:none;padding:0;">
+          ${sectors.map(s=>`<li data-sector="${s}">${capitalize(s)} <button class="up">↑</button><button class="down">↓</button><span class="status" id="status-${s}"></span></li>`).join('')}
+        </ul>
+      </section>
+      <section id="plannerPolicies">
+        <h4>Policies</h4>
+        <label>Tariff Rate (%): <input type="number" id="policy-tariff" min="0" max="100" value="0"></label>
+        <label>FX Swap: <input type="number" id="policy-fxswap" min="0" value="0"></label>
+      </section>
+      <button id="submitPlan">Submit Plan</button>
+    </details>
+  `;
+}
+
+function capitalize(s:string){return s.charAt(0).toUpperCase()+s.slice(1);}
+
+function setupHandlers() {
+  const inputs = document.querySelectorAll('#plannerBudgets input');
+  inputs.forEach(el => el.addEventListener('input', updateBudgetTotals));
+  document.getElementById('sectorList')!.addEventListener('click', e => {
+    const target = e.target as HTMLElement;
+    if (target.classList.contains('up') || target.classList.contains('down')) {
+      const li = target.parentElement as HTMLElement;
+      if (target.classList.contains('up') && li.previousElementSibling) {
+        li.parentElement!.insertBefore(li, li.previousElementSibling);
+      } else if (target.classList.contains('down') && li.nextElementSibling) {
+        li.parentElement!.insertBefore(li.nextElementSibling!, li);
+      }
+    }
+  });
+  document.getElementById('submitPlan')!.addEventListener('click', submitCurrentPlan);
+  (document.getElementById('goldAvailable') as HTMLElement).textContent = String(availableGold);
+}
+
+async function loadPlan() {
+  try {
+    const plan = await fetchPlan(gameId);
+    if (plan?.budgets) {
+      (document.getElementById('budget-military') as HTMLInputElement).value = plan.budgets.military ?? 0;
+      (document.getElementById('budget-welfare') as HTMLInputElement).value = plan.budgets.welfare ?? 0;
+      for (const s of sectors) {
+        const val = plan.budgets.sectorOM?.[s] ?? 0;
+        (document.getElementById(`sector-${s}`) as HTMLInputElement).value = val;
+      }
+    }
+    if (plan?.policies?.welfare) {
+      (document.getElementById('welfare-edu') as HTMLInputElement).value = plan.policies.welfare.education ?? 0;
+      (document.getElementById('welfare-health') as HTMLInputElement).value = plan.policies.welfare.healthcare ?? 0;
+    }
+    if (plan?.policies) {
+      (document.getElementById('policy-tariff') as HTMLInputElement).value = (plan.policies.tariff ?? 0) * 100;
+      (document.getElementById('policy-fxswap') as HTMLInputElement).value = plan.policies.fxSwap ?? 0;
+    }
+  } catch { /* ignore */ }
+}
+
+function getSectorOrder(): string[] {
+  return Array.from(document.querySelectorAll('#sectorList li')).map(li => (li as HTMLElement).dataset['sector']!);
+}
+
+function updateSectorStatus() {
+  for (const sector of sectors) {
+    let funded = 0, idle = 0;
+    for (const canton of Object.values(currentState.economy.cantons || {})) {
+      const st = (canton as any).sectors?.[sector];
+      if (st) {
+        funded += st.funded || 0;
+        idle += st.idle || 0;
+      }
+    }
+    const span = document.getElementById(`status-${sector}`);
+    if (span) span.textContent = ` (Funded: ${funded}, Idle: ${idle}, Stalled: 0)`;
+  }
+}
+
+function computeLabor(economy:any): number {
+  let total = 0;
+  for (const canton of Object.values(economy.cantons || {})) {
+    const l = (canton as any).labor || {general:0,skilled:0,specialist:0};
+    total += l.general + l.skilled + l.specialist;
+  }
+  return total;
+}
+
+function updateBudgetTotals() {
+  const military = Number((document.getElementById('budget-military') as HTMLInputElement).value) || 0;
+  const welfare = Number((document.getElementById('budget-welfare') as HTMLInputElement).value) || 0;
+  let sectorsSum = 0;
+  for (const s of sectors) {
+    sectorsSum += Number((document.getElementById(`sector-${s}`) as HTMLInputElement).value) || 0;
+  }
+  const total = military + welfare + sectorsSum;
+  (document.getElementById('goldAllocated') as HTMLElement).textContent = String(total);
+
+  const overspend = total > availableGold;
+  (document.getElementById('overspendWarning') as HTMLElement).style.display = overspend ? 'block' : 'none';
+  (document.getElementById('militaryWarning') as HTMLElement).style.display = military < militaryUpkeep ? 'block' : 'none';
+
+  const edu = Number((document.getElementById('welfare-edu') as HTMLInputElement).value) || 0;
+  const health = Number((document.getElementById('welfare-health') as HTMLInputElement).value) || 0;
+  const labor = computeLabor(currentState.economy);
+  const welfareCost = labor * (EDUCATION_COST[edu] + HEALTHCARE_COST[health]);
+  (document.getElementById('welfareWarning') as HTMLElement).style.display = welfare < welfareCost ? 'block' : 'none';
+}
+
+async function submitCurrentPlan() {
+  updateBudgetTotals();
+  if ((document.getElementById('overspendWarning') as HTMLElement).style.display === 'block') return;
+  const plan: any = {
+    budgets: {
+      military: Number((document.getElementById('budget-military') as HTMLInputElement).value) || 0,
+      welfare: Number((document.getElementById('budget-welfare') as HTMLInputElement).value) || 0,
+      sectorOM: {} as any,
+    },
+    policies: {
+      welfare: {
+        education: Number((document.getElementById('welfare-edu') as HTMLInputElement).value) || 0,
+        healthcare: Number((document.getElementById('welfare-health') as HTMLInputElement).value) || 0,
+      },
+      tariff: (Number((document.getElementById('policy-tariff') as HTMLInputElement).value) || 0) / 100,
+      fxSwap: Number((document.getElementById('policy-fxswap') as HTMLInputElement).value) || 0,
+    },
+    slotPriorities: {} as any,
+  };
+  for (const s of sectors) {
+    const v = Number((document.getElementById(`sector-${s}`) as HTMLInputElement).value) || 0;
+    if (v) plan.budgets.sectorOM[s] = v;
+  }
+  const order = getSectorOrder();
+  order.forEach((s,i)=> plan.slotPriorities[s] = i);
+  try {
+    await submitTurnPlan(gameId, playerId, plan);
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -197,6 +197,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
     </div>
     </div>
     <div id="gameState" style="display: none;"></div>
+    <div id="gameControls" style="display: none;"></div>
   `;
 
   document.body.appendChild(uiPanel);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,5 @@
 // server/src/index.ts
-import { createGame, fallback, getMesh, joinGame, root, startGame, loadGame, getGameState, submitPlan, advanceTurn, getTurnSummary, leaveGame, endGame, getEconomy, getBudget, getLabor, getLogistics, getEnergy, getSuitability, getDevelopment, getInfrastructure, getFinance, getTrade, getWelfare } from "./routes";
+import { createGame, fallback, getMesh, joinGame, root, startGame, loadGame, getGameState, submitPlan, advanceTurn, getTurnSummary, leaveGame, endGame, getEconomy, getBudget, getLabor, getLogistics, getEnergy, getSuitability, getDevelopment, getInfrastructure, getFinance, getTrade, getWelfare, getPlan } from "./routes";
 import { setupWebSocketHandler } from "./websocket";
 import { ENDPOINTS, PORT } from "./constants";
 import { encode } from "./serialization";
@@ -91,6 +91,7 @@ export const server = Bun.serve({
     },
 
     "/api/games/:gameId/plan": {
+      GET: async req => getPlan(req.params.gameId),
       POST: async req => submitPlan(req.params.gameId, req)
     },
 

--- a/server/src/routes/getPlan.test.ts
+++ b/server/src/routes/getPlan.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test';
+import { GameService } from '../game-state';
+import type { TurnPlan } from '../types';
+import { submitPlan } from './submitPlan';
+import { getPlan } from './getPlan';
+import { advanceTurn } from './advanceTurn';
+import { getGameState } from './getGameState';
+
+async function setupGame() {
+  const cellCount = 16;
+  const biomes = new Uint8Array(cellCount).fill(1);
+  const gameId = 'g' + Math.random().toString(36).slice(2,8);
+  const joinCode = 'J' + Math.random().toString(36).slice(2,7).toUpperCase();
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, 2, biomes);
+  await GameService.joinGame(joinCode);
+  await GameService.startGame(gameId);
+  const state = await GameService.getGameState(gameId);
+  if (state) {
+    state.economy.resources.gold = 100;
+    await GameService.saveGameState(state, gameId);
+  }
+  return { gameId };
+}
+
+test('getPlan returns next-turn plan and plan executes next turn', async () => {
+  const { gameId } = await setupGame();
+  const plan: TurnPlan = { budgets: { military: 5, welfare: 0, sectorOM: {} } } as any;
+  const req = new Request('http://localhost', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ playerId:'player1', plan }) });
+  const res = await submitPlan(gameId, req);
+  expect(res.status).toBe(200);
+
+  const getRes = await getPlan(gameId);
+  expect(getRes.status).toBe(200);
+  const fetched = await getRes.json();
+  expect(fetched.budgets.military).toBe(5);
+
+  const beforeState = await (await getGameState(gameId)).json();
+  expect(beforeState.currentPlan).toBeNull();
+  expect(beforeState.nextPlan.budgets.military).toBe(5);
+
+  const advReq = new Request('http://localhost', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ playerId:'player1' }) });
+  await advanceTurn(gameId, advReq);
+
+  const afterState = await (await getGameState(gameId)).json();
+  expect(afterState.currentPlan.budgets.military).toBe(5);
+});

--- a/server/src/routes/getPlan.ts
+++ b/server/src/routes/getPlan.ts
@@ -1,0 +1,24 @@
+import { CORS_HEADERS } from "../constants";
+import { GameService } from "../game-state";
+
+export async function getPlan(gameId: string) {
+  try {
+    const state = await GameService.getGameState(gameId);
+    if (!state) {
+      return new Response(JSON.stringify({ error: "Game not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+      });
+    }
+    return new Response(JSON.stringify(state.nextPlan || {}), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+  } catch (err) {
+    console.error('get plan error', err);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+    });
+  }
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -22,3 +22,4 @@ export { getInfrastructure } from "./getInfrastructure";
 export { getFinance } from "./getFinance";
 export { getTrade } from "./getTrade";
 export { getWelfare } from "./getWelfare";
+export { getPlan } from "./getPlan";


### PR DESCRIPTION
## Summary
- add Nation Planner interface for budgets, priorities, and policies
- enable fetching and submitting next-turn plans via new API endpoint
- ensure planner shows after game start and validates budget warnings

## Testing
- `npm test`
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68bdf351de548327a6e728aa53630f9a