### PR TITLE
Seed nations with balanced mid-game economy

### DIFF
--- a/server/src/game-state/initialization.test.ts
+++ b/server/src/game-state/initialization.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'bun:test';
+import {
+  GameStateManager,
+  STARTING_RESOURCES_PER_NATION,
+  STARTING_SECTOR_PROFILE,
+  STARTING_URBANIZATION_LEVEL,
+  STARTING_WELFARE_POLICIES,
+  STARTING_ENERGY_PLANTS,
+  STARTING_CREDIT_LIMIT_PER_NATION,
+} from './manager';
+
+function setupState(players: string[]) {
+  const state = GameStateManager.createInitialGameState(players);
+  players.forEach((player, index) => {
+    const base = index * 3;
+    state.playerCells[player] = [base, base + 1, base + 2];
+  });
+  const cellCount = players.length * 3;
+  const biomes = new Uint8Array(cellCount + 1).fill(1);
+  const cellOffsets = new Uint32Array(cellCount + 1);
+  const cellNeighbors = new Int32Array();
+  GameStateManager.initializeNationInfrastructure(
+    state,
+    players,
+    biomes,
+    cellNeighbors,
+    cellOffsets,
+  );
+  return state;
+}
+
+test('initializeNationInfrastructure seeds balanced mid-progress nations', () => {
+  const players = ['p1', 'p2', 'p3'];
+  const state = setupState(players);
+  const economy = state.economy;
+  const multiplier = players.length;
+
+  for (const [res, amount] of Object.entries(STARTING_RESOURCES_PER_NATION)) {
+    expect(economy.resources[res as keyof typeof economy.resources]).toBe(
+      amount * multiplier,
+    );
+  }
+
+  expect(economy.welfare.current).toEqual(STARTING_WELFARE_POLICIES);
+  expect(economy.welfare.next).toEqual(STARTING_WELFARE_POLICIES);
+  expect(economy.finance.creditLimit).toBe(
+    STARTING_CREDIT_LIMIT_PER_NATION * multiplier,
+  );
+
+  const plantsPerNation = STARTING_ENERGY_PLANTS.length;
+  for (const player of players) {
+    const cantonId = String(state.playerCells[player][0]);
+    const canton = economy.cantons[cantonId];
+    expect(canton).toBeDefined();
+    expect(canton.urbanizationLevel).toBe(STARTING_URBANIZATION_LEVEL);
+    for (const [sector, profile] of Object.entries(STARTING_SECTOR_PROFILE)) {
+      const sectorState = canton.sectors[sector as keyof typeof STARTING_SECTOR_PROFILE];
+      expect(sectorState?.capacity).toBe(profile.capacity);
+      expect(canton.suitability[sector as keyof typeof STARTING_SECTOR_PROFILE]).toBe(
+        profile.suitability,
+      );
+    }
+    const assignedPlants = economy.energy.plants.filter(p => p.canton === cantonId);
+    expect(assignedPlants.length).toBe(plantsPerNation);
+  }
+});

--- a/server/src/websocket/turn-events.test.ts
+++ b/server/src/websocket/turn-events.test.ts
@@ -79,7 +79,22 @@ test('websocket turn flow emits ordered events and survives reconnect', async ()
   expect(planEvent.data.playerId).toBe('player1');
   const stateEvents = events1.filter(e => e.event === 'state_change');
   const types = stateEvents.map(e => e.data.type).sort();
-  expect(types).toEqual(['energy_shortage','infrastructure_complete','resource_default','resource_shortage','ul_change'].sort());
+  const allowed = [
+    'energy_shortage',
+    'infrastructure_complete',
+    'resource_default',
+    'resource_shortage',
+    'ul_change',
+  ];
+  expect(types.every(t => allowed.includes(t))).toBe(true);
+  expect(types).toEqual(
+    expect.arrayContaining([
+      'energy_shortage',
+      'infrastructure_complete',
+      'resource_default',
+      'ul_change',
+    ]),
+  );
   const turnEvent = events1.find(e => e.event === 'turn_complete');
   expect(turnEvent.data.turnNumber).toBe(2);
   const seqs = events1.filter(e => e.data?.seq !== undefined).map(e => e.data.seq);


### PR DESCRIPTION
## Summary
- introduce balanced mid-game resources, sector capacities, and welfare policies for new nations
- configure initializeNationInfrastructure to apply the starting profile and seed energy plants per canton
- add a regression test for the starter setup and relax websocket event expectations to allow optional shortages

## Testing
- cd server && bun test

------
https://chatgpt.com/codex/tasks/task_e_68d3574f265c8327bc95c23c0c8b1e98