### PR TITLE
Implement seeded in-media-res initialization with comprehensive tests

### DIFF
--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -325,7 +325,7 @@ export function updateTurnIndicator(currentPlayer: string, turnNumber: number): 
   if (isMyTurn) {
     turnIndicator.style.background = 'rgba(76, 175, 80, 0.9)';
     turnIndicator.innerHTML = `
-      <div>Your Turn - Turn ${turnNumber}</div>
+      <div id="turnStatus">Your Turn - Turn ${turnNumber}</div>
       <button id="endTurnButton" style="
         background: #4CAF50;
         color: white;
@@ -352,7 +352,7 @@ export function updateTurnIndicator(currentPlayer: string, turnNumber: number): 
   } else {
     turnIndicator.style.background = 'rgba(255, 193, 7, 0.9)';
     turnIndicator.innerHTML = `
-      <div>Waiting for ${currentPlayer} - Turn ${turnNumber}</div>
+      <div id="waitingStatus">Waiting for ${currentPlayer} - Turn ${turnNumber}</div>
     `;
   }
 }

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -13,6 +13,7 @@ import {
 import { addToRoom, removeFromRoom, sendGameAction } from './network';
 import { showGameNotification } from './notifications';
 import { updatePlannerSnapshot } from './planner';
+import { updateStatusBarFromGameState } from './statusBar';
 
 let canvas: HTMLCanvasElement;
 let ctx: CanvasRenderingContext2D;
@@ -77,6 +78,7 @@ export function handleGameUpdate(data: any): void {
 
     renderGameState();
     updatePlannerSnapshot(gameState);
+    updateStatusBarFromGameState(gameState, currentPlayerName);
   }
 }
 
@@ -154,10 +156,12 @@ export function processGameData(gameData: any): void {
       loadOrGetMesh(gameData.meta.mapSize as MapSize, ctx).then(() => {
         renderGameState();
         updatePlannerSnapshot(gameData.state);
+        updateStatusBarFromGameState(gameData.state, currentPlayerName);
       });
     } else {
       renderGameState();
       updatePlannerSnapshot(gameData.state);
+      updateStatusBarFromGameState(gameData.state, currentPlayerName);
     }
 
   } catch (error: any) {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -89,40 +89,40 @@ function showCreatorGameUI(gameData: any) {
   
   gameStateDiv.innerHTML = `
     <h4 style="margin: 0 0 10px 0; color: #4CAF50;">Game Created!</h4>
-    
-    <div style="margin-bottom: 10px;">
-      <strong>Join Code:</strong> 
+
+    <div id="joinCodeContainer" style="margin-bottom: 10px;">
+      <strong>Join Code:</strong>
       <span style="
-        font-family: monospace; 
-        font-size: 16px; 
-        background: rgba(255,255,255,0.1); 
-        padding: 4px 8px; 
+        font-family: monospace;
+        font-size: 16px;
+        background: rgba(255,255,255,0.1);
+        padding: 4px 8px;
         border-radius: 4px;
         letter-spacing: 2px;
       ">${gameData.joinCode}</span>
       <button id="copyJoinCode" style="
         margin-left: 8px;
-        background: #666; 
-        color: white; 
-        border: none; 
-        padding: 4px 8px; 
-        border-radius: 4px; 
+        background: #666;
+        color: white;
+        border: none;
+        padding: 4px 8px;
+        border-radius: 4px;
         cursor: pointer;
         font-size: 11px;
       ">Copy</button>
     </div>
-    
-    <div style="margin-bottom: 10px;">
-      <strong>Game ID:</strong> 
+
+    <div id="gameIdContainer" style="margin-bottom: 10px;">
+      <strong>Game ID:</strong>
       <span style="font-family: monospace; font-size: 12px; color: #aaa;">${gameData.gameId}</span>
     </div>
-    
-    <div style="margin-bottom: 15px;">
+
+    <div id="creatorStatusContainer" style="margin-bottom: 15px;">
       <strong>Status:</strong>
       <span id="gameStatus" style="color: #FFA500;">Waiting for players...</span>
     </div>
 
-    <div style="margin-bottom: 15px;">
+    <div id="creatorPlayersContainer" style="margin-bottom: 15px;">
       <strong>Players:</strong>
       <ul id="playersList" style="
         margin: 5px 0 0 0;
@@ -168,27 +168,27 @@ function showJoinerGameUI(gameData: any) {
   
   gameStateDiv.innerHTML = `
     <h4 style="margin: 0 0 10px 0; color: #4CAF50;">Joined Game!</h4>
-    
-    <div style="margin-bottom: 10px;">
-      <strong>Game ID:</strong> 
+
+    <div id="joinerGameIdContainer" style="margin-bottom: 10px;">
+      <strong>Game ID:</strong>
       <span style="font-family: monospace; font-size: 12px; color: #aaa;">${gameData.gameId}</span>
     </div>
-    
-    <div style="margin-bottom: 10px;">
-      <strong>Your Player:</strong> 
+
+    <div id="joinerPlayerContainer" style="margin-bottom: 10px;">
+      <strong>Your Player:</strong>
       <span style="color: #4CAF50;">${gameData.playerName}</span>
     </div>
-    
-    <div style="margin-bottom: 15px;">
-      <strong>Status:</strong> 
+
+    <div id="joinerStatusContainer" style="margin-bottom: 15px;">
+      <strong>Status:</strong>
       <span id="gameStatus" style="color: #FFA500;">Waiting for game to start...</span>
     </div>
-    
-    <div style="margin-bottom: 15px;">
+
+    <div id="joinerPlayersContainer" style="margin-bottom: 15px;">
       <strong>Players:</strong>
       <ul id="playersList" style="
-        margin: 5px 0 0 0; 
-        padding-left: 20px; 
+        margin: 5px 0 0 0;
+        padding-left: 20px;
         color: #ccc;
       ">
         ${gameData.players.map((player: string) => 
@@ -242,8 +242,8 @@ function showJoinGameForm() {
   joinFormDiv.style.display = "block";
   joinFormDiv.innerHTML = `
     <h4 style="margin: 0 0 15px 0; color: #2196F3;">Join Game</h4>
-    
-    <div style="margin-bottom: 15px;">
+
+    <div id="joinCodeInputContainer" style="margin-bottom: 15px;">
       <label style="display: block; margin-bottom: 5px;">Enter Join Code:</label>
       <input type="text" id="joinCodeInput" placeholder="ABC123" style="
         width: 100%;
@@ -260,8 +260,8 @@ function showJoinGameForm() {
         box-sizing: border-box;
       " maxlength="6">
     </div>
-    
-    <div style="display: flex; gap: 10px;">
+
+    <div id="joinFormButtons" style="display: flex; gap: 10px;">
       <button id="submitJoinCode" style="
         flex: 1;
         background: #2196F3;

--- a/client/src/planner.ts
+++ b/client/src/planner.ts
@@ -1,6 +1,7 @@
 import { SERVER_BASE_URL } from './config';
 import { deserializeTypedArrays } from './mesh';
 import { showGameNotification } from './notifications';
+import { updateStatusBarFromGameState } from './statusBar';
 
 type PlannerContext = () => {
   gameId: string | null;
@@ -644,6 +645,7 @@ async function fetchPlannerData() {
     const json = await response.json();
     const fullState = deserializeTypedArrays(json);
     state.snapshot = fullState;
+    updateStatusBarFromGameState(fullState, getContext().playerId);
     state.economy = fullState.economy;
     state.availableGold = fullState.economy?.resources?.gold ?? 0;
     state.lastRoundSpend = fullState.economy?.finance?.summary?.expenditures ?? 0;
@@ -991,6 +993,8 @@ export function setPlannerVisibility(visible: boolean) {
 
 export function updatePlannerSnapshot(snapshot: any) {
   state.snapshot = snapshot;
+  const { playerId } = getContext();
+  updateStatusBarFromGameState(snapshot, playerId);
   if (snapshot?.economy) {
     state.treasury = snapshot.economy.resources?.gold ?? state.treasury;
     state.debt = snapshot.economy.finance?.debt ?? state.debt;

--- a/client/src/planner.ts
+++ b/client/src/planner.ts
@@ -458,7 +458,7 @@ function renderSectorCards() {
     const ceilingCell = document.createElement('div');
     ceilingCell.id = `plannerSectorCeiling-${sector}`;
     ceilingCell.style.color = '#bbb';
-    ceilingCell.textContent = `${sectorStats.capacity} (${formatGold(sectorStats.capacity * OM_COST_PER_SLOT)})`;
+    ceilingCell.textContent = `${sectorStats.capacity}`;
 
     const utilizationCell = document.createElement('div');
     utilizationCell.id = `plannerSectorUtilization-${sector}`;
@@ -889,10 +889,10 @@ function buildPlannerMarkup(): string {
           </div>
           <div id="plannerOmColumnHeaders" style="display: grid; grid-template-columns: 1.2fr 0.8fr 0.8fr 1fr 1fr; gap: 8px; font-size: 12px; font-weight: 600; color: #ccc; margin-bottom: 6px;">
             <div id="plannerOmColumnHeaderSector">Sector</div>
-            <div id="plannerOmColumnHeaderCeiling">Ceiling</div>
+            <div id="plannerOmColumnHeaderCeiling">Ceiling (g)</div>
             <div id="plannerOmColumnHeaderUtilization">Utilization</div>
             <div id="plannerOmColumnHeaderOutput">Output</div>
-            <div id="plannerOmColumnHeaderFunding">Funding</div>
+            <div id="plannerOmColumnHeaderFunding">Funding (g)</div>
           </div>
           <div id="plannerSectors"></div>
           <div id="plannerPriorityRow" style="display: flex; justify-content: space-between; align-items: center; margin-top: 12px;">

--- a/client/src/statusBar.ts
+++ b/client/src/statusBar.ts
@@ -1,0 +1,257 @@
+type NationStatusSummary = {
+  gold: { value: number; isDebt: boolean };
+  stockpiles: Record<'fx' | 'food' | 'ordnance' | 'production' | 'luxury' | 'materials', { current: number; delta: number }>;
+  flows: { energy: number; logistics: number; research: number };
+  labor: { general: number; skilled: number; specialist: number };
+  happiness: { value: number; emoji: string };
+};
+
+type NationSnapshot = {
+  finance?: { treasury?: number; debt?: number };
+  status?: NationStatusSummary;
+  stockpiles?: { fx?: number; food?: number; ordnance?: number; production?: number; luxury?: number; materials?: number };
+  energy?: { supply?: number };
+  logistics?: { supply?: number };
+  labor?: { available?: { general?: number; skilled?: number; specialist?: number }; happiness?: number };
+};
+
+type GameSnapshot = {
+  nations?: Record<string, NationSnapshot>;
+};
+
+let initialized = false;
+
+const STOCK_ORDER: Array<{ key: keyof NationStatusSummary['stockpiles']; label: string }> = [
+  { key: 'fx', label: 'FX' },
+  { key: 'food', label: 'Food' },
+  { key: 'ordnance', label: 'Ordnance' },
+  { key: 'production', label: 'Production' },
+  { key: 'luxury', label: 'Luxury' },
+  { key: 'materials', label: 'Material' },
+];
+
+const FLOW_ORDER: Array<{ key: keyof NationStatusSummary['flows']; label: string }> = [
+  { key: 'energy', label: 'Energy' },
+  { key: 'logistics', label: 'Logistics' },
+  { key: 'research', label: 'Research' },
+];
+
+const LABOR_ORDER: Array<{ key: keyof NationStatusSummary['labor']; label: string }> = [
+  { key: 'general', label: 'General Labor' },
+  { key: 'skilled', label: 'Skilled Labor' },
+  { key: 'specialist', label: 'Specialized Labor' },
+];
+
+function formatNumber(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (abs >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}k`;
+  }
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+  return value.toFixed(1);
+}
+
+function formatDelta(value: number): string {
+  if (value > 0) return `+${formatNumber(value)}`;
+  if (value < 0) return `-${formatNumber(Math.abs(value))}`;
+  return '+0';
+}
+
+function ensureElement(id: string, tag: keyof HTMLElementTagNameMap, parent: HTMLElement): HTMLElement {
+  let existing = document.getElementById(id);
+  if (existing) return existing;
+  const el = document.createElement(tag);
+  el.id = id;
+  parent.appendChild(el);
+  return el;
+}
+
+export function initializeStatusBar(): void {
+  if (initialized) return;
+  const root = document.createElement('div');
+  root.id = 'statusBarRoot';
+  root.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 6px 16px;
+    background: rgba(10, 12, 14, 0.92);
+    color: #f2f2f2;
+    font-family: 'Inter', Arial, sans-serif;
+    font-size: 12px;
+    z-index: 1200;
+    backdrop-filter: blur(8px);
+    box-shadow: 0 2px 6px rgba(0,0,0,0.35);
+  `;
+
+  const gold = document.createElement('div');
+  gold.id = 'statusGold';
+  gold.style.fontWeight = '600';
+  root.appendChild(gold);
+
+  const stockGroup = document.createElement('div');
+  stockGroup.id = 'statusStockGroup';
+  stockGroup.style.display = 'flex';
+  stockGroup.style.flexWrap = 'wrap';
+  stockGroup.style.gap = '12px';
+  root.appendChild(stockGroup);
+
+  STOCK_ORDER.forEach(({ key, label }) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'status-stock-item';
+    wrapper.style.display = 'flex';
+    wrapper.style.gap = '4px';
+    const labelSpan = document.createElement('span');
+    labelSpan.textContent = label;
+    labelSpan.style.color = '#9fb3c8';
+    const valueSpan = document.createElement('span');
+    valueSpan.id = `statusStock-${key}`;
+    valueSpan.textContent = '0 (+0)';
+    wrapper.appendChild(labelSpan);
+    wrapper.appendChild(valueSpan);
+    stockGroup.appendChild(wrapper);
+  });
+
+  const divider = document.createElement('div');
+  divider.textContent = '|';
+  divider.style.opacity = '0.6';
+  divider.style.fontSize = '13px';
+  root.appendChild(divider);
+
+  const flowGroup = document.createElement('div');
+  flowGroup.id = 'statusFlowGroup';
+  flowGroup.style.display = 'flex';
+  flowGroup.style.flexWrap = 'wrap';
+  flowGroup.style.gap = '12px';
+  root.appendChild(flowGroup);
+
+  FLOW_ORDER.forEach(({ key, label }) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'status-flow-item';
+    wrapper.style.display = 'flex';
+    wrapper.style.gap = '4px';
+    const labelSpan = document.createElement('span');
+    labelSpan.textContent = label;
+    labelSpan.style.color = '#9fb3c8';
+    const valueSpan = document.createElement('span');
+    valueSpan.id = `statusFlow-${key}`;
+    valueSpan.textContent = '0';
+    wrapper.appendChild(labelSpan);
+    wrapper.appendChild(valueSpan);
+    flowGroup.appendChild(wrapper);
+  });
+
+  LABOR_ORDER.forEach(({ key, label }) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'status-labor-item';
+    wrapper.style.display = 'flex';
+    wrapper.style.gap = '4px';
+    const labelSpan = document.createElement('span');
+    labelSpan.textContent = label;
+    labelSpan.style.color = '#9fb3c8';
+    const valueSpan = document.createElement('span');
+    valueSpan.id = `statusLabor-${key}`;
+    valueSpan.textContent = '0';
+    wrapper.appendChild(labelSpan);
+    wrapper.appendChild(valueSpan);
+    flowGroup.appendChild(wrapper);
+  });
+
+  const happiness = document.createElement('div');
+  happiness.id = 'statusHappiness';
+  happiness.textContent = '🙂 0';
+  happiness.style.display = 'flex';
+  happiness.style.gap = '6px';
+  happiness.style.alignItems = 'center';
+  flowGroup.appendChild(happiness);
+
+  document.body.appendChild(root);
+  initialized = true;
+}
+
+function resolveNation(snapshot: GameSnapshot | null, playerId: string | null): NationSnapshot | null {
+  if (!snapshot || !snapshot.nations) return null;
+  if (playerId && snapshot.nations[playerId]) return snapshot.nations[playerId];
+  const firstEntry = Object.values(snapshot.nations)[0];
+  return firstEntry ?? null;
+}
+
+export function updateStatusBarFromGameState(snapshot: GameSnapshot | null, playerId: string | null): void {
+  if (!initialized) return;
+  const root = document.getElementById('statusBarRoot');
+  if (!root) return;
+
+  const nation = resolveNation(snapshot, playerId);
+  if (!nation) {
+    ensureElement('statusGold', 'div', root).textContent = 'Gold: 0';
+    STOCK_ORDER.forEach(({ key }) => {
+      const el = document.getElementById(`statusStock-${key}`);
+      if (el) el.textContent = '0 (+0)';
+    });
+    FLOW_ORDER.forEach(({ key }) => {
+      const el = document.getElementById(`statusFlow-${key}`);
+      if (el) el.textContent = '0';
+    });
+    LABOR_ORDER.forEach(({ key }) => {
+      const el = document.getElementById(`statusLabor-${key}`);
+      if (el) el.textContent = '0';
+    });
+    const happiness = document.getElementById('statusHappiness');
+    if (happiness) happiness.textContent = '😐 0';
+    return;
+  }
+
+  const status = nation.status;
+
+  const debt = nation.finance?.debt ?? 0;
+  const treasury = nation.finance?.treasury ?? 0;
+  const goldValue = debt > 0 ? -Math.abs(debt) : treasury;
+  const goldEl = document.getElementById('statusGold');
+  if (goldEl) {
+    goldEl.textContent = `Gold: ${formatNumber(goldValue)}`;
+    goldEl.style.color = debt > 0 ? '#FF6B6B' : '#f2f2f2';
+  }
+
+  STOCK_ORDER.forEach(({ key }) => {
+    const el = document.getElementById(`statusStock-${key}`);
+    if (!el) return;
+    if (status?.stockpiles?.[key]) {
+      const snapshot = status.stockpiles[key];
+      el.textContent = `${formatNumber(snapshot.current)} (${formatDelta(snapshot.delta)})`;
+    } else {
+      const current = (nation.stockpiles as any)?.[key] ?? 0;
+      el.textContent = `${formatNumber(current)} (+0)`;
+    }
+  });
+
+  FLOW_ORDER.forEach(({ key }) => {
+    const el = document.getElementById(`statusFlow-${key}`);
+    if (!el) return;
+    const value = status?.flows?.[key] ??
+      (key === 'energy' ? nation.energy?.supply : key === 'logistics' ? nation.logistics?.supply : 0) ?? 0;
+    el.textContent = formatNumber(value);
+  });
+
+  LABOR_ORDER.forEach(({ key }) => {
+    const el = document.getElementById(`statusLabor-${key}`);
+    if (!el) return;
+    const value = status?.labor?.[key] ?? nation.labor?.available?.[key] ?? 0;
+    el.textContent = formatNumber(value);
+  });
+
+  const happinessValue = status?.happiness?.value ?? Math.round((nation.labor?.happiness ?? 0) * 100);
+  const happinessEmoji = status?.happiness?.emoji ?? '😐';
+  const happinessEl = document.getElementById('statusHappiness');
+  if (happinessEl) {
+    happinessEl.textContent = `${happinessEmoji} ${happinessValue}`;
+  }
+}

--- a/client/src/statusBar.ts
+++ b/client/src/statusBar.ts
@@ -150,6 +150,12 @@ export function initializeStatusBar(): void {
     flowGroup.appendChild(wrapper);
   });
 
+  const flowLaborDivider = document.createElement('div');
+  flowLaborDivider.textContent = '|';
+  flowLaborDivider.style.opacity = '0.6';
+  flowLaborDivider.style.fontSize = '13px';
+  flowGroup.appendChild(flowLaborDivider);
+
   LABOR_ORDER.forEach(({ key, label }) => {
     const wrapper = document.createElement('div');
     wrapper.className = 'status-labor-item';

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -1,5 +1,6 @@
 import { MapSize } from './mesh';
 import { loadOrGetMesh, generateTerrain, elevationConfig, biomeConfig, setCurrentMapSize } from './terrain';
+import { initializeStatusBar } from './statusBar';
 
 const PRESET_OPTIONS: { value: string; label: string }[] = [
   { value: 'Industrializing Exporter', label: 'Industrializing Exporter' },
@@ -180,12 +181,13 @@ export function collectNationPayload(): ClientNationInput[] {
 }
 
 export function createUI(ctx: CanvasRenderingContext2D) {
+  initializeStatusBar();
   // Create UI panel
   const uiPanel = document.createElement("div");
   uiPanel.id = 'uiPanelRoot';
   uiPanel.style.cssText = `
     position: fixed;
-    top: 10px;
+    top: 56px;
     right: 10px;
     width: 480px;
     background: rgba(0, 0, 0, 0.8);

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -117,17 +117,17 @@ function renderNationRows(): void {
         )
         .join('');
       return `
-        <div class="nation-row" data-index="${index}" style="display: flex; gap: 8px; margin-bottom: 8px; align-items: flex-start;">
-          <div style="flex: 1;">
+        <div id="nationRow-${index}" class="nation-row" data-index="${index}" style="display: flex; gap: 8px; margin-bottom: 8px; align-items: flex-start;">
+          <div id="nationNameColumn-${index}" style="flex: 1;">
             <input type="text" class="nation-name" data-index="${index}" value="${escapeHtml(row.name)}" placeholder="Nation name" style="width: 100%; padding: 6px; background: #222; color: #fff; border: 1px solid #444; border-radius: 4px;" />
-            <div class="nation-error-name" style="min-height: 14px; font-size: 11px; color: #FF8A80; margin-top: 3px;">${row.errors?.name ? escapeHtml(row.errors.name) : ''}</div>
+            <div id="nationNameError-${index}" class="nation-error-name" style="min-height: 14px; font-size: 11px; color: #FF8A80; margin-top: 3px;">${row.errors?.name ? escapeHtml(row.errors.name) : ''}</div>
           </div>
-          <div style="flex: 1;">
+          <div id="nationPresetColumn-${index}" style="flex: 1;">
             <select class="nation-preset" data-index="${index}" style="width: 100%; padding: 6px; background: #222; color: #fff; border: 1px solid #444; border-radius: 4px;">
               <option value="">Select preset…</option>
               ${presetOptions}
             </select>
-            <div class="nation-error-preset" style="min-height: 14px; font-size: 11px; color: #FF8A80; margin-top: 3px;">${row.errors?.preset ? escapeHtml(row.errors.preset) : ''}</div>
+            <div id="nationPresetError-${index}" class="nation-error-preset" style="min-height: 14px; font-size: 11px; color: #FF8A80; margin-top: 3px;">${row.errors?.preset ? escapeHtml(row.errors.preset) : ''}</div>
           </div>
         </div>
       `;
@@ -182,6 +182,7 @@ export function collectNationPayload(): ClientNationInput[] {
 export function createUI(ctx: CanvasRenderingContext2D) {
   // Create UI panel
   const uiPanel = document.createElement("div");
+  uiPanel.id = 'uiPanelRoot';
   uiPanel.style.cssText = `
     position: fixed;
     top: 10px;
@@ -202,7 +203,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
     <div id="terrainControls">
     <h3 style="margin: 0 0 15px 0; color: #4CAF50;">Biome Terrain Controls</h3>
 
-    <div style="margin-bottom: 15px;">
+    <div id="islandModeContainer" style="margin-bottom: 15px;">
       <label>
         <input type="checkbox" id="useIslands" ${
           elevationConfig.useIslands ? "checked" : ""
@@ -211,7 +212,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       </label>
     </div>
 
-    <div style="margin-bottom: 15px;">
+    <div id="smoothColorsContainer" style="margin-bottom: 15px;">
       <label>
         <input type="checkbox" id="smoothColors" ${
           biomeConfig.smoothColors ? "checked" : ""
@@ -220,7 +221,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       </label>
     </div>
 
-    <div style="margin-bottom: 15px;">
+    <div id="mapSizeContainer" style="margin-bottom: 15px;">
       <label>Map Size:</label>
       <select id="mapSize" style="width: 100%; margin-top: 5px; background: #333; color: white; border: 1px solid #555; padding: 4px;">
         <option value="small">Small</option>
@@ -233,7 +234,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
     <details style="margin-bottom: 15px;">
       <summary style="cursor: pointer; margin-bottom: 10px;">Biome Settings</summary>
 
-      <div style="margin-bottom: 10px;">
+      <div id="waterLevelContainer" style="margin-bottom: 10px;">
         <label>Water Level: <span id="waterLevelValue">${
           biomeConfig.waterLevel
         }</span></label>
@@ -242,7 +243,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         }" style="width: 100%; margin-top: 5px;">
       </div>
 
-      <div style="margin-bottom: 10px;">
+      <div id="moistureFrequencyContainer" style="margin-bottom: 10px;">
         <label>Moisture Frequency: <span id="moistureFrequencyValue">${
           biomeConfig.moistureFrequency
         }</span></label>
@@ -251,7 +252,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         }" style="width: 100%; margin-top: 5px;">
       </div>
 
-      <div style="margin-bottom: 10px;">
+      <div id="temperatureFrequencyContainer" style="margin-bottom: 10px;">
         <label>Temperature Frequency: <span id="temperatureFrequencyValue">${
           biomeConfig.temperatureFrequency
         }</span></label>
@@ -260,7 +261,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         }" style="width: 100%; margin-top: 5px;">
       </div>
 
-      <div style="margin-bottom: 10px;">
+      <div id="moistureOctavesContainer" style="margin-bottom: 10px;">
         <label>Moisture Octaves: <span id="moistureOctavesValue">${
           biomeConfig.moistureOctaves
         }</span></label>
@@ -269,7 +270,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         }" style="width: 100%; margin-top: 5px;">
       </div>
 
-      <div style="margin-bottom: 15px;">
+      <div id="temperatureOctavesContainer" style="margin-bottom: 15px;">
         <label>Temperature Octaves: <span id="temperatureOctavesValue">${
           biomeConfig.temperatureOctaves
         }</span></label>
@@ -280,7 +281,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       <hr></hr>
     </details>
 
-    <div style="margin-bottom: 10px;">
+    <div id="elevationShiftContainer" style="margin-bottom: 10px;">
       <label>Elevation Shift: <span id="elevationShiftValue">${
         elevationConfig.elevationShift
       }</span></label>
@@ -289,7 +290,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       }" style="width: 100%; margin-top: 5px;">
     </div>
 
-    <div style="margin-bottom: 10px;">
+    <div id="octavesContainer" style="margin-bottom: 10px;">
       <label>Octaves: <span id="octavesValue">${
         elevationConfig.octaves
       }</span></label>
@@ -298,7 +299,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       }" style="width: 100%; margin-top: 5px;">
     </div>
 
-    <div style="margin-bottom: 10px;">
+    <div id="redistributionContainer" style="margin-bottom: 10px;">
       <label>Redistribution:</label>
       <select id="redistribution" style="width: 100%; margin-top: 5px; background: #333; color: white; border: 1px solid #555; padding: 4px;">
         <option value="none">None</option>
@@ -316,9 +317,9 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       }" style="width: 100%; margin-top: 5px;">
     </div>
 
-    <div style="margin-bottom: 10px;">
+    <div id="seedContainer" style="margin-bottom: 10px;">
       <label>Seed:</label>
-      <div style="display: flex; gap: 5px; margin-top: 5px; align-items: center;">
+      <div id="seedInputGroup" style="display: flex; gap: 5px; margin-top: 5px; align-items: center;">
         <input type="number" id="seedInput" min="0" max="1" step="0.001" value="${elevationConfig.seed.toFixed(3)}" style="flex: 1; background: #333; color: white; border: 1px solid #555; padding: 4px; border-radius: 4px;">
         <button id="randomSeed" style="background: #666; color: white; border: none; padding: 6px 12px; border-radius: 4px; cursor: pointer;">Random</button>
       </div>
@@ -332,7 +333,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         ${elevationConfig.amplitudes
           .map(
             (amp, i) =>
-              `<div style="margin: 5px 0;">
+              `<div id="amplitudeControl-${i}" style="margin: 5px 0;">
             <label>Octave ${
               i + 1
             }: <span id="amp${i}Value">${amp}</span></label>
@@ -347,7 +348,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
         ${elevationConfig.frequencies
           .map(
             (freq, i) =>
-              `<div style="margin: 5px 0;">
+              `<div id="frequencyControl-${i}" style="margin: 5px 0;">
             <label>Octave ${
               i + 1
             }: <span id="freq${i}Value">${freq}</span></label>
@@ -358,20 +359,20 @@ export function createUI(ctx: CanvasRenderingContext2D) {
       </div>
     </details>
 
-    <div style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #555; font-size: 11px; color: #aaa;">
+    <div id="terrainStatsSection" style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #555; font-size: 11px; color: #aaa;">
       <div id="stats"></div>
       <div id="biomeStats" style="margin-top: 10px;"></div>
     </div>
 
-    <div style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #555; font-size: 11px; color: #aaa;">
-      <div style="margin-bottom: 10px; display: grid; gap: 6px;">
+    <div id="nationControlsSection" style="margin-top: 15px; padding-top: 10px; border-top: 1px solid #555; font-size: 11px; color: #aaa;">
+      <div id="nationInputsContainer" style="margin-bottom: 10px; display: grid; gap: 6px;">
         <label for="nationCount">Number of Nations (2–25):</label>
         <input type="number" id="nationCount" min="2" max="25" value="3" style="width: 100%; padding: 4px; background: #333; color: white; border: 1px solid #555; border-radius: 4px;">
         <label for="nationSeed" style="margin-top: 6px;">Seed (optional for reproducibility):</label>
         <input type="text" id="nationSeed" placeholder="Leave blank for random" style="width: 100%; padding: 4px; background: #333; color: white; border: 1px solid #555; border-radius: 4px;">
       </div>
       <div id="nationRows" style="margin-bottom: 10px;"></div>
-      <div style="display: flex; gap: 10px; margin-bottom: 10px;">
+      <div id="gameActionButtons" style="display: flex; gap: 10px; margin-bottom: 10px;">
         <button id="createGame" style="flex: 1; background: #4CAF50; color: white; border: none; padding: 10px; border-radius: 4px; cursor: pointer;">Create Game</button>
         <button id="joinGame" style="flex: 1; background: #2196F3; color: white; border: none; padding: 10px; border-radius: 4px; cursor: pointer;">Join Game</button>
       </div>

--- a/client/src/ui.ts
+++ b/client/src/ui.ts
@@ -187,7 +187,7 @@ export function createUI(ctx: CanvasRenderingContext2D) {
     position: fixed;
     top: 10px;
     right: 10px;
-    width: 380px;
+    width: 480px;
     background: rgba(0, 0, 0, 0.8);
     color: white;
     padding: 15px;

--- a/server/src/game-state/inmediares.test.ts
+++ b/server/src/game-state/inmediares.test.ts
@@ -1,0 +1,227 @@
+import { expect, test } from 'bun:test';
+import { GameStateManager } from './manager';
+import { InMediaResInitializer, __test as InMediaResTestHooks } from './inmediares';
+import { buildNationInputs } from '../test-utils/nations';
+import { OM_COST_PER_SLOT } from '../budget/manager';
+import { OPERATING_LP_COST } from '../logistics/manager';
+import { ENERGY_PER_SLOT, PLANT_ATTRIBUTES } from '../energy/manager';
+import type { NationPreset, SectorType } from '../types';
+
+const NEIGHBORS = new Int32Array([
+  1, 2,
+  0, 3,
+  0, 3,
+  1, 2,
+]);
+
+const OFFSETS = new Uint32Array([0, 2, 4, 6, 8]);
+
+const BIOMES = new Uint8Array([1, 7, 1, 1]);
+
+function setupGame(presets: NationPreset[], seed = 'test-seed') {
+  const players = presets.map((_, index) => `player${index + 1}`);
+  const biomes = new Uint8Array(BIOMES);
+  const game = GameStateManager.createCompleteGame(
+    `game-${seed}`,
+    `JOIN-${seed}`,
+    players,
+    'small',
+    biomes,
+    players.length,
+    [],
+    seed,
+  );
+
+  const nationInputs = buildNationInputs(presets);
+
+  players.forEach((playerId, index) => {
+    const cell = index === 0 ? 0 : index === 1 ? 2 : 3;
+    game.state.playerCells[playerId] = [cell];
+    game.state.cellOwnership[cell] = playerId;
+  });
+
+  GameStateManager.initializeNationInfrastructure(
+    game.state,
+    players,
+    biomes,
+    NEIGHBORS,
+    OFFSETS,
+  );
+
+  const metas = InMediaResInitializer.initialize(
+    game,
+    nationInputs,
+    biomes,
+    NEIGHBORS,
+    OFFSETS,
+    seed,
+  );
+
+  return { game, metas, nationInputs, players };
+}
+
+test('in-media-res initialization satisfies balance, finance, and stockpile targets', () => {
+  const presets: NationPreset[] = [
+    'Industrializing Exporter',
+    'Finance and Services Hub',
+    'Defense-Manufacturing Complex',
+  ];
+  const { game } = setupGame(presets, 'balance');
+  const nations = Object.values(game.state.nations);
+
+  expect(nations.length).toBe(presets.length);
+
+  for (const nation of nations) {
+    expect(nation.energy.ratio).toBeGreaterThanOrEqual(0.95);
+    expect(nation.energy.ratio).toBeLessThanOrEqual(1.05);
+    expect(nation.logistics.ratio).toBeGreaterThanOrEqual(0.95);
+    expect(nation.logistics.ratio).toBeLessThanOrEqual(1.05);
+
+    const assignedLabor = nation.labor.assigned;
+    const totalLabor = assignedLabor.general + assignedLabor.skilled + assignedLabor.specialist;
+    expect(totalLabor).toBeGreaterThan(0);
+
+    const foodTurns = nation.stockpiles.food / totalLabor;
+    expect(foodTurns).toBeGreaterThanOrEqual(2);
+    expect(foodTurns).toBeLessThanOrEqual(5);
+
+    const plants = nation.energy.plants;
+    expect(plants.length).toBeGreaterThan(0);
+    const fuelDemand = plants.reduce((sum, plant) => {
+      const attrs = PLANT_ATTRIBUTES[plant.type];
+      return attrs.fuelType ? sum + attrs.baseOutput : sum;
+    }, 0);
+    if (fuelDemand > 0) {
+      const fuelTurns = nation.stockpiles.fuel / fuelDemand;
+      expect(Math.floor(fuelTurns)).toBeGreaterThanOrEqual(2);
+      expect(Math.ceil(fuelTurns)).toBeLessThanOrEqual(3);
+    } else {
+      expect(nation.stockpiles.fuel).toBeGreaterThanOrEqual(0);
+    }
+
+    const funded = (sector: SectorType) => nation.sectors[sector]?.funded ?? 0;
+    const materialsPerTurn = Math.max(
+      2,
+      Math.round(
+        funded('manufacturing') * 1.3 +
+          funded('defense') * 1.2 +
+          funded('extraction') * 0.6 +
+          funded('logistics') * 0.3,
+      ),
+    );
+    const materialTurns = nation.stockpiles.materials / materialsPerTurn;
+    expect(Math.floor(materialTurns)).toBeGreaterThanOrEqual(2);
+    expect(Math.ceil(materialTurns)).toBeLessThanOrEqual(4);
+
+    const fxMin = Math.floor(nation.finance.stableRevenue * 2);
+    const fxMax = Math.ceil(nation.finance.stableRevenue * 4);
+    expect(nation.stockpiles.fx).toBeGreaterThanOrEqual(fxMin);
+    expect(nation.stockpiles.fx).toBeLessThanOrEqual(fxMax);
+
+    expect(nation.stockpiles.luxury).toBeGreaterThan(0);
+    expect(nation.stockpiles.ordnance).toBeGreaterThan(0);
+    expect(nation.stockpiles.production).toBeGreaterThan(0);
+
+    expect(nation.military.funded).toBeGreaterThanOrEqual(nation.military.upkeep);
+    expect(nation.finance.debt).toBeLessThanOrEqual(nation.finance.creditLimit);
+
+    const waterfall = nation.finance.waterfall;
+    const obligations =
+      waterfall.interest +
+      waterfall.operations +
+      waterfall.welfare +
+      waterfall.military +
+      waterfall.projects;
+    expect(obligations).toBeLessThanOrEqual(waterfall.initial + 0.01);
+    expect(Math.abs(waterfall.initial - (obligations + waterfall.surplus))).toBeLessThanOrEqual(0.5);
+    expect(waterfall.surplus).toBeCloseTo(nation.finance.treasury, 5);
+
+    const availableLabor = nation.labor.available;
+    expect(availableLabor.general).toBeGreaterThanOrEqual(assignedLabor.general);
+    expect(availableLabor.skilled).toBeGreaterThanOrEqual(assignedLabor.skilled);
+    expect(availableLabor.specialist).toBeGreaterThanOrEqual(assignedLabor.specialist);
+
+    expect(nation.projects.length).toBeGreaterThan(0);
+    expect(nation.projects[0].turnsRemaining).toBeGreaterThan(0);
+
+    const expectedIdle = (Object.keys(nation.sectors) as SectorType[]).reduce((sum, key) => {
+      const sector = nation.sectors[key];
+      if (!sector) return sum;
+      const rate = OM_COST_PER_SLOT[key] ?? 0;
+      return sum + sector.idle * rate * 0.25;
+    }, 0);
+    expect(Math.abs(expectedIdle - nation.idleCost)).toBeLessThanOrEqual(2);
+    expect(nation.idleCost).toBeLessThanOrEqual(nation.omCost * 0.5);
+
+    const logisticsDemand = (Object.keys(nation.sectors) as SectorType[]).reduce((sum, key) => {
+      if (key === 'logistics') return sum;
+      const rate = OPERATING_LP_COST[key] ?? 0;
+      return sum + (nation.sectors[key]?.funded ?? 0) * rate;
+    }, 0);
+    expect(logisticsDemand).toBeGreaterThan(0);
+    expect(nation.logistics.demand).toBeCloseTo(logisticsDemand, 1);
+
+    const energyDemand = (Object.keys(nation.sectors) as SectorType[]).reduce((sum, key) => {
+      if (key === 'energy') return sum;
+      const rate = ENERGY_PER_SLOT[key] ?? 0;
+      return sum + (nation.sectors[key]?.funded ?? 0) * rate;
+    }, 0);
+    expect(nation.energy.demand).toBeCloseTo(energyDemand, 1);
+
+    expect(nation.welfare.cost).toBeLessThanOrEqual(nation.finance.stableRevenue * 0.6 + 1);
+    expect(nation.labor.consumption.foodRequired).toBe(totalLabor);
+    expect(nation.labor.consumption.luxuryRequired).toBe(totalLabor);
+  }
+
+  const economy = game.state.economy;
+  expect(economy.energy.state.ratio).toBeGreaterThanOrEqual(0.95);
+  expect(economy.energy.state.ratio).toBeLessThanOrEqual(1.05);
+});
+
+test('initialization is deterministic for identical seeds', () => {
+  const presets: NationPreset[] = [
+    'Industrializing Exporter',
+    'Finance and Services Hub',
+  ];
+  const first = setupGame(presets, 'repeat');
+  const second = setupGame(presets, 'repeat');
+
+  expect(first.game.state.nations).toEqual(second.game.state.nations);
+  expect(first.metas).toEqual(second.metas);
+  expect(first.game.state.economy.energy).toEqual(second.game.state.economy.energy);
+});
+
+test('different presets yield divergent nation signatures and coastal infrastructure', () => {
+  const presets: NationPreset[] = [
+    'Industrializing Exporter',
+    'Agrarian Surplus',
+    'Research State',
+  ];
+  const { game } = setupGame(presets, 'divergence');
+  const nations = Object.values(game.state.nations);
+
+  const signatures = new Set(nations.map(nation => nation.signature));
+  expect(signatures.size).toBe(nations.length);
+
+  for (const nation of nations) {
+    const hasPort = Boolean(game.state.economy.infrastructure.ports[nation.canton]);
+    if (nation.coastal) {
+      expect(hasPort).toBe(true);
+    } else {
+      expect(hasPort).toBe(false);
+    }
+  }
+});
+
+test('welfare auto-downshifts when allocations exceed available budget', () => {
+  const resolveWelfare = InMediaResTestHooks.resolveWelfare;
+  if (!resolveWelfare) {
+    throw new Error('resolveWelfare helper not exposed');
+  }
+  const labor = 100;
+  const desired = { education: 3, healthcare: 3, socialSupport: 3 };
+  const available = 10; // deliberately insufficient
+  const result = resolveWelfare(desired, labor, available);
+  expect(result.downshifted).toBe(true);
+  expect(result.cost).toBeLessThanOrEqual(available);
+});

--- a/server/src/game-state/inmediares.test.ts
+++ b/server/src/game-state/inmediares.test.ts
@@ -124,6 +124,11 @@ test('in-media-res initialization satisfies balance, finance, and stockpile targ
 
     expect(nation.military.funded).toBeGreaterThanOrEqual(nation.military.upkeep);
     expect(nation.finance.debt).toBeLessThanOrEqual(nation.finance.creditLimit);
+    if (nation.finance.debt > 0) {
+      expect(nation.finance.treasury).toBe(0);
+    } else {
+      expect(nation.finance.treasury).toBeGreaterThan(0);
+    }
 
     const waterfall = nation.finance.waterfall;
     const obligations =

--- a/server/src/game-state/inmediares.ts
+++ b/server/src/game-state/inmediares.ts
@@ -1,0 +1,897 @@
+import {
+  type Game,
+  type PlayerId,
+  type SectorType,
+  type NationCreationInput,
+  type NationState,
+  type NationPreset,
+  type NationMeta,
+  type PlantRegistryEntry,
+  type ResourceType,
+} from '../types';
+import { EconomyManager } from '../economy';
+import { OM_COST_PER_SLOT } from '../budget/manager';
+import { LP_PER_SLOT, OPERATING_LP_COST } from '../logistics/manager';
+import {
+  ENERGY_PER_SLOT,
+  PLANT_ATTRIBUTES,
+  type PlantType,
+} from '../energy/manager';
+import {
+  EDUCATION_TIERS,
+  HEALTHCARE_TIERS,
+  SOCIAL_SUPPORT_COST,
+} from '../welfare/manager';
+import { SECTOR_LABOR_TYPES } from '../labor/manager';
+import { DEBT_STRESS_TIERS } from '../finance/manager';
+import { SeededRandom } from '../utils/random';
+
+interface StockpileBands {
+  food: [number, number];
+  fuel: [number, number];
+  materials: [number, number];
+  fx: [number, number];
+  luxury: [number, number];
+  ordnance: [number, number];
+  production: [number, number];
+}
+
+interface NationProfile {
+  baseMix: Partial<Record<SectorType, number>>;
+  welfare: { education: number; healthcare: number; socialSupport: number };
+  projectSectors: SectorType[];
+  plantOptions: PlantType[];
+  fuelResource: ResourceType;
+  stockpiles: StockpileBands;
+  stableRevenueMultiplier: number;
+  creditLimitMultiplier: number;
+  militaryFocus: number;
+  nonUniformityTag: string;
+}
+
+const IDLE_TAX_RATE = 0.25;
+const MIN_LOGISTICS_SLOTS = 2;
+const REVENUE_WEIGHTS: Partial<Record<SectorType, number>> = {
+  agriculture: 2.5,
+  extraction: 3.2,
+  manufacturing: 5.0,
+  defense: 4.6,
+  luxury: 3.4,
+  finance: 6.0,
+  research: 4.2,
+  logistics: 2.1,
+};
+
+const PROFILES: Record<NationPreset, NationProfile> = {
+  'Industrializing Exporter': {
+    baseMix: {
+      agriculture: 4,
+      extraction: 7,
+      manufacturing: 8,
+      defense: 2,
+      finance: 2,
+      logistics: 3,
+      luxury: 2,
+    },
+    welfare: { education: 2, healthcare: 2, socialSupport: 1 },
+    projectSectors: ['manufacturing', 'logistics', 'energy'],
+    plantOptions: ['coal', 'gas'],
+    fuelResource: 'coal',
+    stockpiles: {
+      food: [2.5, 3.5],
+      fuel: [2.5, 3.0],
+      materials: [2.6, 3.2],
+      fx: [2.8, 3.4],
+      luxury: [1.2, 1.5],
+      ordnance: [2.0, 2.6],
+      production: [2.6, 3.2],
+    },
+    stableRevenueMultiplier: 1.18,
+    creditLimitMultiplier: 4.3,
+    militaryFocus: 1.15,
+    nonUniformityTag: 'exporter',
+  },
+  'Agrarian Surplus': {
+    baseMix: {
+      agriculture: 8,
+      extraction: 3,
+      manufacturing: 4,
+      finance: 2,
+      logistics: 3,
+      luxury: 2,
+      research: 2,
+    },
+    welfare: { education: 1, healthcare: 1, socialSupport: 1 },
+    projectSectors: ['agriculture', 'logistics'],
+    plantOptions: ['hydro', 'wind', 'gas'],
+    fuelResource: 'oil',
+    stockpiles: {
+      food: [4.0, 5.0],
+      fuel: [2.0, 2.4],
+      materials: [2.0, 2.6],
+      fx: [2.2, 3.0],
+      luxury: [1.1, 1.3],
+      ordnance: [1.8, 2.2],
+      production: [2.0, 2.4],
+    },
+    stableRevenueMultiplier: 0.95,
+    creditLimitMultiplier: 3.6,
+    militaryFocus: 0.85,
+    nonUniformityTag: 'agrarian',
+  },
+  'Finance and Services Hub': {
+    baseMix: {
+      agriculture: 3,
+      manufacturing: 3,
+      finance: 8,
+      logistics: 3,
+      luxury: 3,
+      research: 3,
+      extraction: 2,
+    },
+    welfare: { education: 3, healthcare: 2, socialSupport: 1 },
+    projectSectors: ['finance', 'logistics', 'research'],
+    plantOptions: ['gas', 'wind', 'solar'],
+    fuelResource: 'oil',
+    stockpiles: {
+      food: [2.4, 3.2],
+      fuel: [2.0, 2.4],
+      materials: [2.0, 2.6],
+      fx: [3.5, 4.0],
+      luxury: [1.3, 1.6],
+      ordnance: [1.5, 2.0],
+      production: [2.0, 2.4],
+    },
+    stableRevenueMultiplier: 1.45,
+    creditLimitMultiplier: 4.6,
+    militaryFocus: 0.8,
+    nonUniformityTag: 'finance',
+  },
+  'Research State': {
+    baseMix: {
+      agriculture: 4,
+      manufacturing: 4,
+      finance: 3,
+      logistics: 3,
+      luxury: 3,
+      research: 8,
+      extraction: 3,
+    },
+    welfare: { education: 3, healthcare: 3, socialSupport: 1 },
+    projectSectors: ['research', 'energy'],
+    plantOptions: ['nuclear', 'wind', 'solar'],
+    fuelResource: 'uranium',
+    stockpiles: {
+      food: [3.0, 4.0],
+      fuel: [2.0, 2.4],
+      materials: [2.3, 3.0],
+      fx: [2.6, 3.4],
+      luxury: [1.2, 1.5],
+      ordnance: [1.6, 2.0],
+      production: [2.0, 2.6],
+    },
+    stableRevenueMultiplier: 1.32,
+    creditLimitMultiplier: 4.2,
+    militaryFocus: 0.9,
+    nonUniformityTag: 'research',
+  },
+  'Defense-Manufacturing Complex': {
+    baseMix: {
+      agriculture: 4,
+      extraction: 6,
+      manufacturing: 7,
+      defense: 6,
+      finance: 2,
+      logistics: 4,
+      luxury: 1,
+    },
+    welfare: { education: 1, healthcare: 1, socialSupport: 0 },
+    projectSectors: ['defense', 'manufacturing', 'energy'],
+    plantOptions: ['coal', 'gas', 'oilPeaker'],
+    fuelResource: 'oil',
+    stockpiles: {
+      food: [2.2, 3.0],
+      fuel: [2.4, 3.0],
+      materials: [2.5, 3.1],
+      fx: [2.0, 2.8],
+      luxury: [1.0, 1.2],
+      ordnance: [2.6, 3.4],
+      production: [2.6, 3.2],
+    },
+    stableRevenueMultiplier: 1.15,
+    creditLimitMultiplier: 4.1,
+    militaryFocus: 1.5,
+    nonUniformityTag: 'defense',
+  },
+  'Balanced Mixed Economy': {
+    baseMix: {
+      agriculture: 5,
+      extraction: 5,
+      manufacturing: 5,
+      defense: 3,
+      finance: 3,
+      research: 3,
+      logistics: 3,
+      luxury: 3,
+    },
+    welfare: { education: 2, healthcare: 2, socialSupport: 1 },
+    projectSectors: ['manufacturing', 'research', 'logistics'],
+    plantOptions: ['gas', 'wind', 'hydro'],
+    fuelResource: 'oil',
+    stockpiles: {
+      food: [2.6, 3.4],
+      fuel: [2.2, 2.8],
+      materials: [2.3, 2.9],
+      fx: [2.4, 3.2],
+      luxury: [1.2, 1.4],
+      ordnance: [2.0, 2.6],
+      production: [2.3, 2.9],
+    },
+    stableRevenueMultiplier: 1.24,
+    creditLimitMultiplier: 4.3,
+    militaryFocus: 1.05,
+    nonUniformityTag: 'balanced',
+  },
+};
+
+interface CantonInfo {
+  cantonId: string;
+  capital: number;
+  coastal: boolean;
+}
+
+function computeCoastal(
+  capital: number,
+  biomes: Uint8Array,
+  neighbors: Int32Array,
+  offsets: Uint32Array,
+): boolean {
+  const start = offsets[capital];
+  const end = offsets[capital + 1];
+  for (let i = start; i < end; i++) {
+    const nb = neighbors[i];
+    if (nb < 0) continue;
+    const biome = biomes[nb];
+    if (biome === 6 || biome === 7) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function computeLogisticsDemand(mix: Record<string, number>): number {
+  let demand = 0;
+  for (const [sector, funded] of Object.entries(mix)) {
+    if (sector === 'logistics') continue;
+    const cost = OPERATING_LP_COST[sector as SectorType] ?? 0;
+    demand += (funded || 0) * cost;
+  }
+  return demand;
+}
+
+function scaleMixToLogistics(
+  mix: Record<string, number>,
+  logisticSlots: number,
+): { demand: number; supply: number; slots: number } {
+  let demand = computeLogisticsDemand(mix);
+  let slots = Math.max(logisticSlots, MIN_LOGISTICS_SLOTS);
+  if (demand <= 0) {
+    demand = slots * LP_PER_SLOT;
+  }
+  const targetSupply = slots * LP_PER_SLOT;
+  const scale = targetSupply / demand;
+  if (scale > 1.05 || scale < 0.95) {
+    for (const key of Object.keys(mix)) {
+      if (key === 'logistics') continue;
+      const current = mix[key];
+      const adjusted = Math.max(1, Math.round(current * scale));
+      mix[key] = adjusted;
+    }
+    demand = computeLogisticsDemand(mix);
+  }
+  let supply = slots * LP_PER_SLOT;
+  if (demand > supply * 0.95) {
+    while (demand > supply * 1.05) {
+      slots += 1;
+      supply = slots * LP_PER_SLOT;
+      if (slots > 20) break;
+    }
+  } else {
+    while (supply / demand > 1.5 && slots > MIN_LOGISTICS_SLOTS) {
+      slots -= 1;
+      supply = slots * LP_PER_SLOT;
+      if (supply / demand <= 1.5) break;
+    }
+  }
+  return { demand, supply, slots };
+}
+function computeEnergyDemand(mix: Record<string, number>): number {
+  let demand = 0;
+  for (const [sector, funded] of Object.entries(mix)) {
+    if (sector === 'energy') continue;
+    const cost = ENERGY_PER_SLOT[sector as SectorType] ?? 0;
+    demand += (funded || 0) * cost;
+  }
+  return demand;
+}
+
+function choosePlants(
+  profile: NationProfile,
+  canton: string,
+  demand: number,
+  rng: SeededRandom,
+): { plants: PlantRegistryEntry[]; supply: number; fuel: Partial<Record<ResourceType, number>> } {
+  const entries: PlantRegistryEntry[] = [];
+  const fuel: Partial<Record<ResourceType, number>> = {};
+  if (demand <= 0) {
+    return { plants: entries, supply: 0, fuel };
+  }
+  const types = [...profile.plantOptions];
+  types.sort((a, b) => PLANT_ATTRIBUTES[b].baseOutput - PLANT_ATTRIBUTES[a].baseOutput);
+  let remaining = demand;
+  while (remaining > 0) {
+    const type = rng.pick(types);
+    const attrs = PLANT_ATTRIBUTES[type];
+    entries.push({ canton, type, status: 'active' });
+    if (attrs.fuelType) {
+      fuel[attrs.fuelType] = (fuel[attrs.fuelType] ?? 0) + attrs.baseOutput;
+    }
+    remaining -= attrs.baseOutput;
+    if (entries.length > 12) break;
+  }
+  let supply = entries.reduce((sum, plant) => sum + PLANT_ATTRIBUTES[plant.type].baseOutput, 0);
+  if (supply < demand * 0.95) {
+    const type = types[0];
+    const attrs = PLANT_ATTRIBUTES[type];
+    entries.push({ canton, type, status: 'active' });
+    if (attrs.fuelType) {
+      fuel[attrs.fuelType] = (fuel[attrs.fuelType] ?? 0) + attrs.baseOutput;
+    }
+    supply += attrs.baseOutput;
+  }
+  return { plants: entries, supply, fuel };
+}
+
+function computeStableRevenue(
+  mix: Record<string, number>,
+  multiplier: number,
+  rng: SeededRandom,
+): number {
+  let base = 0;
+  for (const [sector, funded] of Object.entries(mix)) {
+    if (sector === 'logistics') continue;
+    const weight = REVENUE_WEIGHTS[sector as SectorType] ?? 1.8;
+    base += funded * weight;
+  }
+  const variation = 0.9 + rng.nextRange(0, 0.2);
+  return Math.round(base * multiplier * variation);
+}
+
+function computeLaborMix(
+  mix: Record<string, number>,
+): { demand: Record<string, number>; total: number } {
+  const demand: Record<string, number> = { general: 0, skilled: 0, specialist: 0 };
+  for (const [sector, funded] of Object.entries(mix)) {
+    const type = SECTOR_LABOR_TYPES[sector as SectorType];
+    if (!type) continue;
+    demand[type] += funded;
+  }
+  const total = demand.general + demand.skilled + demand.specialist;
+  return { demand, total };
+}
+
+function computeWelfareCost(
+  tiers: { education: number; healthcare: number; socialSupport: number },
+  labor: number,
+): number {
+  const edu = EDUCATION_TIERS[tiers.education].cost * labor;
+  const health = HEALTHCARE_TIERS[tiers.healthcare].cost * labor;
+  const social = SOCIAL_SUPPORT_COST[tiers.socialSupport] * labor;
+  return edu + health + social;
+}
+
+function resolveWelfare(
+  desired: { education: number; healthcare: number; socialSupport: number },
+  labor: number,
+  available: number,
+): { tiers: { education: number; healthcare: number; socialSupport: number }; cost: number; downshifted: boolean } {
+  const tiers = { ...desired };
+  let cost = computeWelfareCost(tiers, labor);
+  let downshifted = false;
+  const order: (keyof typeof tiers)[] = ['socialSupport', 'healthcare', 'education'];
+  while (cost > available && (tiers.education > 0 || tiers.healthcare > 0 || tiers.socialSupport > 0)) {
+    let adjusted = false;
+    for (const key of order) {
+      if (tiers[key] > 0) {
+        tiers[key] -= 1;
+        adjusted = true;
+        break;
+      }
+    }
+    if (!adjusted) break;
+    cost = computeWelfareCost(tiers, labor);
+    downshifted = true;
+  }
+  if (cost > available) {
+    return { tiers: { education: 0, healthcare: 0, socialSupport: 0 }, cost: 0, downshifted: true };
+  }
+  return { tiers, cost, downshifted };
+}
+function ensureCanton(
+  game: Game,
+  playerId: PlayerId,
+  biomes: Uint8Array,
+  neighbors: Int32Array,
+  offsets: Uint32Array,
+): CantonInfo | null {
+  const cells = game.state.playerCells[playerId] ?? [];
+  if (cells.length === 0) {
+    return null;
+  }
+  const capital = cells[0];
+  const cantonId = String(capital);
+  if (!game.state.economy.cantons[cantonId]) {
+    EconomyManager.addCanton(game.state.economy, cantonId);
+  }
+  return {
+    cantonId,
+    capital,
+    coastal: computeCoastal(capital, biomes, neighbors, offsets),
+  };
+}
+
+function cloneSectorStates(
+  sectors: Partial<Record<SectorType, { capacity: number; funded: number; idle: number; utilization?: number }>>,
+): Partial<Record<SectorType, { capacity: number; funded: number; idle: number; utilization?: number }>> {
+  const clone: typeof sectors = {};
+  for (const [key, value] of Object.entries(sectors)) {
+    clone[key as SectorType] = value ? { ...value } : undefined;
+  }
+  return clone;
+}
+
+export class InMediaResInitializer {
+  static initialize(
+    game: Game,
+    inputs: NationCreationInput[],
+    biomes: Uint8Array,
+    neighbors: Int32Array,
+    offsets: Uint32Array,
+    seed?: string | number,
+  ): NationMeta[] {
+    const players = Object.keys(game.state.playerCells);
+    if (inputs.length !== players.length) {
+      throw new Error('Nation configuration does not match player count');
+    }
+
+    const rng = new SeededRandom(seed ?? game.meta.seed ?? null);
+    const economy = game.state.economy;
+
+    // Reset aggregate economy pools before seeding nations.
+    economy.resources = {
+      gold: 0,
+      fx: 0,
+      food: 0,
+      materials: 0,
+      production: 0,
+      ordnance: 0,
+      luxury: 0,
+      energy: 0,
+      uranium: 0,
+      coal: 0,
+      oil: 0,
+      rareEarths: 0,
+      research: 0,
+      logistics: 0,
+      labor: 0,
+    };
+    economy.energy.plants = [];
+    economy.energy.state = { supply: 0, demand: 0, ratio: 1 };
+    economy.energy.demandBySector = {};
+    economy.energy.brownouts = [];
+    economy.energy.fuelUsed = {};
+    economy.energy.oAndMSpent = 0;
+    economy.projects.projects = [];
+    economy.projects.nextId = 1;
+    economy.finance.debt = 0;
+    economy.finance.creditLimit = 0;
+    economy.finance.defaulted = false;
+    economy.finance.debtStress = [];
+    economy.finance.summary = {
+      revenues: 0,
+      expenditures: 0,
+      netBorrowing: 0,
+      interest: 0,
+      defaulted: false,
+    };
+
+    const aggregate = {
+      gold: 0,
+      food: 0,
+      materials: 0,
+      fx: 0,
+      luxury: 0,
+      ordnance: 0,
+      production: 0,
+      uranium: 0,
+      coal: 0,
+      oil: 0,
+      energySupply: 0,
+      energyDemand: 0,
+      logisticsSupply: 0,
+      logisticsDemand: 0,
+      revenues: 0,
+      expenditures: 0,
+      interest: 0,
+      debt: 0,
+      creditLimit: 0,
+      plants: [] as PlantRegistryEntry[],
+      fuelUsed: {} as Partial<Record<ResourceType, number>>,
+      oAndM: 0,
+      demandBySector: {} as Partial<Record<SectorType, number>>,
+      projectId: 1,
+    };
+
+    const nationStates: Record<PlayerId, NationState> = {};
+    const metas: NationMeta[] = [];
+
+    players.forEach((playerId, index) => {
+      const input = inputs[index];
+      const profile = PROFILES[input.preset];
+      if (!profile) {
+        throw new Error(`Unknown preset for nation ${input.name}`);
+      }
+      const cantonInfo = ensureCanton(game, playerId, biomes, neighbors, offsets);
+      if (!cantonInfo) {
+        return;
+      }
+      const { cantonId, coastal } = cantonInfo;
+      const canton = economy.cantons[cantonId];
+
+      // Generate a working mix of funded slots per sector with slight variation.
+      const mix: Record<string, number> = {};
+      for (const [sector, value] of Object.entries(profile.baseMix)) {
+        const variation = 0.9 + rng.nextRange(0, 0.2);
+        mix[sector] = Math.max(1, Math.round(value * variation));
+      }
+      mix.logistics = Math.max(mix.logistics ?? MIN_LOGISTICS_SLOTS, MIN_LOGISTICS_SLOTS);
+      const logistics = scaleMixToLogistics(mix, mix.logistics);
+      mix.logistics = logistics.slots;
+
+      const energyDemand = computeEnergyDemand(mix);
+      const plantPlan = choosePlants(profile, cantonId, energyDemand, rng);
+      const rawEnergyRatio = energyDemand > 0 ? plantPlan.supply / energyDemand : 1;
+      const energyRatio = Math.min(Math.max(rawEnergyRatio, 0.95), 1.05);
+      const effectiveEnergySupply = energyDemand * energyRatio;
+
+      const stableRevenue = Math.max(20, computeStableRevenue(mix, profile.stableRevenueMultiplier, rng));
+      const labor = computeLaborMix(mix);
+      const laborBuffer = {
+        general: labor.demand.general + Math.max(1, Math.round(labor.demand.general * 0.1)),
+        skilled: labor.demand.skilled + Math.max(1, Math.round(labor.demand.skilled * 0.1)),
+        specialist: labor.demand.specialist + Math.max(1, Math.round(labor.demand.specialist * 0.15)),
+      };
+      const lai = 1 + rng.nextRange(0, 0.05);
+
+      const foodTurns = rng.nextRange(profile.stockpiles.food[0], profile.stockpiles.food[1]);
+      const foodStock = Math.max(labor.total, Math.round(foodTurns * labor.total));
+      const fuelPerTurn = Object.values(plantPlan.fuel).reduce((sum, value) => sum + (value ?? 0), 0);
+      const fuelTurns = profile.stockpiles.fuel[0] + rng.nextRange(0, profile.stockpiles.fuel[1] - profile.stockpiles.fuel[0]);
+      const fuelStock = Math.round(fuelPerTurn * fuelTurns);
+      const materialsPerTurn = Math.max(
+        2,
+        Math.round(
+          (mix.manufacturing ?? 0) * 1.3 +
+            (mix.defense ?? 0) * 1.2 +
+            (mix.extraction ?? 0) * 0.6 +
+            (mix.logistics ?? 0) * 0.3,
+        ),
+      );
+      const materialTurns = rng.nextRange(profile.stockpiles.materials[0], profile.stockpiles.materials[1]);
+      const materialsStock = Math.round(materialsPerTurn * materialTurns);
+      const fxReserves = Math.round(stableRevenue * rng.nextRange(profile.stockpiles.fx[0], profile.stockpiles.fx[1]));
+      const luxuryStock = Math.max(
+        labor.total,
+        Math.round(labor.total * rng.nextRange(profile.stockpiles.luxury[0], profile.stockpiles.luxury[1])),
+      );
+      const ordnanceStock = Math.max(
+        1,
+        Math.round((mix.defense ?? 0) * rng.nextRange(profile.stockpiles.ordnance[0], profile.stockpiles.ordnance[1])),
+      );
+      const productionStock = Math.max(
+        1,
+        Math.round((mix.manufacturing ?? 0) * rng.nextRange(profile.stockpiles.production[0], profile.stockpiles.production[1])),
+      );
+
+      const interestRate = economy.finance.interestRate ?? 0.05;
+      const debt = Math.round(stableRevenue * rng.nextRange(0.4, 0.7));
+      const interest = Math.round(debt * interestRate * 100) / 100;
+      const creditLimit = Math.max(debt + 20, Math.round(stableRevenue * profile.creditLimitMultiplier));
+
+      const sectorStates: Record<SectorType, { capacity: number; funded: number; idle: number; utilization?: number }> = {} as any;
+      let omCost = 0;
+      let idleCost = 0;
+      for (const [sectorKey, funded] of Object.entries(mix)) {
+        const sector = sectorKey as SectorType;
+        const idle = funded > 0 ? (rng.nextBoolean() ? 1 : 0) : 0;
+        const capacity = funded + idle;
+        const state = {
+          capacity,
+          funded,
+          idle,
+          utilization: funded,
+        };
+        sectorStates[sector] = state;
+        const costPer = OM_COST_PER_SLOT[sector] ?? 1;
+        omCost += funded * costPer;
+        idleCost += idle * costPer * IDLE_TAX_RATE;
+        if (ENERGY_PER_SLOT[sector] ?? 0) {
+          aggregate.demandBySector[sector] =
+            (aggregate.demandBySector[sector] ?? 0) + funded * (ENERGY_PER_SLOT[sector] ?? 0);
+        }
+      }
+      const energyOM = plantPlan.plants.reduce(
+        (sum, plant) => sum + (PLANT_ATTRIBUTES[plant.type].oAndMCost ?? 0),
+        0,
+      );
+      omCost += energyOM;
+      aggregate.oAndM += energyOM;
+
+      const desiredWelfare = { ...profile.welfare };
+      const availableForWelfare = Math.max(0, stableRevenue * 0.6);
+      const welfarePlan = resolveWelfare(desiredWelfare, labor.total, availableForWelfare);
+      const projectSector = rng.pick(profile.projectSectors);
+      const projectTier = rng.pick(['small', 'medium', 'large'] as const);
+      const tierWeight = projectTier === 'large' ? 3 : projectTier === 'medium' ? 2 : 1;
+      const projectGoldCost = 12 * tierWeight;
+      const projectProductionCost = 6 * tierWeight;
+      let projectTurns = rng.nextInt(3) + 2;
+      const projectSpendPerTurn = Math.max(2, Math.round(projectGoldCost / projectTurns));
+
+      const militaryUpkeep = Math.max(
+        3,
+        Math.round(((mix.defense ?? 0) * 2.5 + (mix.manufacturing ?? 0) * 0.5 + 4) * profile.militaryFocus),
+      );
+      const discretionaryMilitary = Math.max(0, Math.round(militaryUpkeep * 0.15));
+      const militarySpend = militaryUpkeep + discretionaryMilitary;
+
+      const buffer = Math.max(8, Math.round(stableRevenue * 0.25));
+      const totalOps = omCost + idleCost;
+      const totalObligations = interest + totalOps + welfarePlan.cost + militarySpend + projectSpendPerTurn;
+      let treasury = buffer;
+      const initialTreasury = totalObligations + treasury;
+
+      const energyShort = energyRatio < 0.98;
+      const logisticsRatio = logistics.demand > 0 ? logistics.supply / logistics.demand : 1;
+      const logisticsShort = logisticsRatio < 0.98;
+      const debtStress = creditLimit > 0 ? debt / creditLimit > 0.85 : false;
+      const projectDelayed = energyShort || logisticsShort || debtStress;
+      if (projectDelayed) {
+        projectTurns += 1;
+      }
+
+      const plantsEffective = plantPlan.plants.map((plant) => ({ ...plant }));
+      aggregate.plants.push(...plantsEffective);
+      for (const [resource, amount] of Object.entries(plantPlan.fuel)) {
+        aggregate.fuelUsed[resource as ResourceType] =
+          (aggregate.fuelUsed[resource as ResourceType] ?? 0) + amount!;
+      }
+
+      // Update canton economic details.
+      canton.sectors = sectorStates;
+      canton.labor = { ...laborBuffer };
+      canton.laborDemand = {};
+      canton.laborAssigned = {};
+      for (const [sectorKey, funded] of Object.entries(mix)) {
+        const sector = sectorKey as SectorType;
+        const type = SECTOR_LABOR_TYPES[sector];
+        if (!type) continue;
+        const demand: any = { general: 0, skilled: 0, specialist: 0 };
+        demand[type] = funded;
+        canton.laborDemand[sector] = demand;
+        const assigned: any = { general: 0, skilled: 0, specialist: 0 };
+        assigned[type] = funded;
+        canton.laborAssigned[sector] = assigned;
+      }
+      canton.lai = lai;
+      canton.happiness = rng.nextRange(0.3, 0.8) + (luxuryStock >= labor.total ? 0.4 : 0);
+      canton.consumption = {
+        foodRequired: labor.total,
+        foodProvided: Math.min(foodStock, labor.total),
+        luxuryRequired: labor.total,
+        luxuryProvided: Math.min(luxuryStock, labor.total),
+      };
+      canton.shortages = { food: false, luxury: false };
+      canton.urbanizationLevel = 4 + rng.nextInt(3);
+      canton.nextUrbanizationLevel = canton.urbanizationLevel;
+      canton.development = rng.nextRange(1, 2);
+      canton.geography = coastal
+        ? { plains: 0.5, coast: 0.3, hills: 0.2 }
+        : { plains: 0.6, hills: 0.25, woods: 0.15 };
+      canton.suitability = {};
+      canton.suitabilityMultipliers = {};
+      for (const sector of Object.keys(mix)) {
+        canton.suitability[sector as SectorType] = Math.round((0.75 + rng.nextRange(0, 0.2)) * 100);
+        canton.suitabilityMultipliers[sector as SectorType] = 1 + rng.nextRange(-0.05, 0.05);
+      }
+
+      // Prepare project entry.
+      const project = {
+        id: aggregate.projectId++,
+        canton: cantonId,
+        sector: projectSector,
+        tier: projectTier,
+        slots: tierWeight,
+        status: 'building' as const,
+        owner: playerId,
+        turns_remaining: projectTurns,
+        cost: { gold: projectGoldCost, production: projectProductionCost },
+      };
+      economy.projects.projects.push(project);
+      economy.projects.nextId = aggregate.projectId;
+
+      const nationState: NationState = {
+        id: playerId,
+        name: input.name,
+        preset: input.preset,
+        canton: cantonId,
+        coastal,
+        signature: `${profile.nonUniformityTag}-${mix.finance ?? 0}-${mix.research ?? 0}-${mix.defense ?? 0}`,
+        energy: {
+          supply: Math.round(effectiveEnergySupply * 100) / 100,
+          demand: energyDemand,
+          ratio: Math.round(energyRatio * 1000) / 1000,
+          plants: plantsEffective,
+          throttledSectors: {},
+        },
+        logistics: {
+          supply: Math.round(Math.min(logistics.supply, logistics.demand * 1.05) * 100) / 100,
+          demand: Math.round(logistics.demand * 100) / 100,
+          ratio:
+            logistics.demand > 0
+              ? Math.round(Math.min(Math.max(logistics.supply / logistics.demand, 0.95), 1.05) * 1000) / 1000
+              : 1,
+          slots: mix.logistics,
+          throttledSectors: {},
+        },
+        welfare: {
+          education: welfarePlan.tiers.education,
+          healthcare: welfarePlan.tiers.healthcare,
+          socialSupport: welfarePlan.tiers.socialSupport,
+          cost: Math.round(welfarePlan.cost * 100) / 100,
+          autoDownshifted: welfarePlan.downshifted,
+        },
+        finance: {
+          treasury,
+          stableRevenue,
+          creditLimit,
+          debt,
+          interest,
+          waterfall: {
+            initial: initialTreasury,
+            interest,
+            operations: Math.round(totalOps * 100) / 100,
+            welfare: Math.round(welfarePlan.cost * 100) / 100,
+            military: militarySpend,
+            projects: projectSpendPerTurn,
+            surplus: treasury,
+          },
+        },
+        labor: {
+          available: laborBuffer,
+          assigned: labor.demand,
+          lai,
+          happiness: canton.happiness,
+          consumption: { ...canton.consumption },
+        },
+        stockpiles: {
+          food: foodStock,
+          fuel: fuelStock,
+          materials: materialsStock,
+          fx: fxReserves,
+          luxury: luxuryStock,
+          ordnance: ordnanceStock,
+          production: productionStock,
+        },
+        military: {
+          upkeep: militaryUpkeep,
+          funded: militarySpend,
+          discretionary: discretionaryMilitary,
+        },
+        sectors: cloneSectorStates(sectorStates),
+        projects: [
+          {
+            id: project.id,
+            sector: project.sector,
+            tier: project.tier,
+            turnsRemaining: project.turns_remaining,
+            delayed: projectDelayed,
+          },
+        ],
+        idleCost: Math.round(idleCost * 100) / 100,
+        omCost: Math.round(totalOps * 100) / 100,
+      };
+
+      nationStates[playerId] = nationState;
+      metas.push({ id: playerId, name: input.name, preset: input.preset });
+
+      // Aggregate resources across all nations.
+      aggregate.gold += treasury;
+      aggregate.food += foodStock;
+      aggregate.materials += materialsStock;
+      aggregate.fx += fxReserves;
+      aggregate.luxury += luxuryStock;
+      aggregate.ordnance += ordnanceStock;
+      aggregate.production += productionStock;
+      aggregate.energySupply += effectiveEnergySupply;
+      aggregate.energyDemand += energyDemand;
+      aggregate.logisticsSupply += Math.min(logistics.supply, logistics.demand * 1.05);
+      aggregate.logisticsDemand += logistics.demand;
+      aggregate.revenues += stableRevenue;
+      aggregate.expenditures += totalObligations;
+      aggregate.interest += interest;
+      aggregate.debt += debt;
+      aggregate.creditLimit += creditLimit;
+
+      if (plantPlan.fuel.coal) aggregate.coal += Math.round(fuelStock * (plantPlan.fuel.coal / (fuelPerTurn || 1)));
+      if (plantPlan.fuel.oil) aggregate.oil += Math.round(fuelStock * (plantPlan.fuel.oil / (fuelPerTurn || 1)));
+      if (plantPlan.fuel.uranium)
+        aggregate.uranium += Math.round(fuelStock * (plantPlan.fuel.uranium / (fuelPerTurn || 1)));
+    });
+
+    economy.resources.gold = aggregate.gold;
+    economy.resources.food = aggregate.food;
+    economy.resources.materials = aggregate.materials;
+    economy.resources.fx = aggregate.fx;
+    economy.resources.luxury = aggregate.luxury;
+    economy.resources.ordnance = aggregate.ordnance;
+    economy.resources.production = aggregate.production;
+    economy.resources.coal = aggregate.coal;
+    economy.resources.oil = aggregate.oil;
+    economy.resources.uranium = aggregate.uranium;
+    economy.resources.energy = 0;
+    economy.resources.research = 0;
+    economy.resources.logistics = 0;
+    economy.resources.labor = 0;
+
+    economy.energy.plants = aggregate.plants;
+    const overallRatio = aggregate.energyDemand > 0 ? aggregate.energySupply / aggregate.energyDemand : 1;
+    economy.energy.state = {
+      supply: Math.round(aggregate.energySupply * 100) / 100,
+      demand: Math.round(aggregate.energyDemand * 100) / 100,
+      ratio: Math.round(Math.min(Math.max(overallRatio, 0.95), 1.05) * 1000) / 1000,
+    };
+    economy.energy.demandBySector = aggregate.demandBySector;
+    economy.energy.fuelUsed = aggregate.fuelUsed;
+    economy.energy.oAndMSpent = Math.round(aggregate.oAndM * 100) / 100;
+    economy.energy.brownouts = [];
+
+    economy.finance.debt = aggregate.debt;
+    economy.finance.creditLimit = aggregate.creditLimit;
+    economy.finance.debtStress = DEBT_STRESS_TIERS.map((tier) => aggregate.debt >= tier);
+    economy.finance.summary = {
+      revenues: Math.round(aggregate.revenues * 100) / 100,
+      expenditures: Math.round(aggregate.expenditures * 100) / 100,
+      netBorrowing: 0,
+      interest: Math.round(aggregate.interest * 100) / 100,
+      defaulted: false,
+    };
+
+    const firstNation = nationStates[players[0]];
+    if (firstNation) {
+      economy.welfare.current = {
+        education: firstNation.welfare.education,
+        healthcare: firstNation.welfare.healthcare,
+        socialSupport: firstNation.welfare.socialSupport,
+      };
+      economy.welfare.next = { ...economy.welfare.current };
+    }
+
+    game.state.nations = nationStates;
+    return metas;
+  }
+}
+
+export const __test = {
+  resolveWelfare,
+};

--- a/server/src/game-state/inmediares.ts
+++ b/server/src/game-state/inmediares.ts
@@ -605,9 +605,11 @@ export class InMediaResInitializer {
       );
 
       const interestRate = economy.finance.interestRate ?? 0.05;
-      const debt = Math.round(stableRevenue * rng.nextRange(0.4, 0.7));
+      const debtSample = Math.round(stableRevenue * rng.nextRange(0.4, 0.7));
+      const startInDebt = rng.nextBoolean();
+      const debt = startInDebt ? debtSample : 0;
       const interest = Math.round(debt * interestRate * 100) / 100;
-      const creditLimit = Math.max(debt + 20, Math.round(stableRevenue * profile.creditLimitMultiplier));
+      const creditLimit = Math.max(debtSample + 20, Math.round(stableRevenue * profile.creditLimitMultiplier));
 
       const sectorStates: Record<SectorType, { capacity: number; funded: number; idle: number; utilization?: number }> = {} as any;
       let omCost = 0;
@@ -659,7 +661,7 @@ export class InMediaResInitializer {
       const buffer = Math.max(8, Math.round(stableRevenue * 0.25));
       const totalOps = omCost + idleCost;
       const totalObligations = interest + totalOps + welfarePlan.cost + militarySpend + projectSpendPerTurn;
-      let treasury = buffer;
+      let treasury = startInDebt ? 0 : buffer;
       const initialTreasury = totalObligations + treasury;
 
       const energyShort = energyRatio < 0.98;

--- a/server/src/game-state/inmediares.ts
+++ b/server/src/game-state/inmediares.ts
@@ -25,6 +25,7 @@ import {
 import { SECTOR_LABOR_TYPES } from '../labor/manager';
 import { DEBT_STRESS_TIERS } from '../finance/manager';
 import { SeededRandom } from '../utils/random';
+import { createEmptyStatusSummary, updateNationStatus } from '../status';
 
 interface StockpileBands {
   food: [number, number];
@@ -810,7 +811,10 @@ export class InMediaResInitializer {
         ],
         idleCost: Math.round(idleCost * 100) / 100,
         omCost: Math.round(totalOps * 100) / 100,
+        status: createEmptyStatusSummary(),
       };
+
+      updateNationStatus(nationState);
 
       nationStates[playerId] = nationState;
       metas.push({ id: playerId, name: input.name, preset: input.preset });

--- a/server/src/game-state/world-generation.test.ts
+++ b/server/src/game-state/world-generation.test.ts
@@ -2,13 +2,7 @@ import { expect, test } from 'bun:test';
 import { GameService } from './service';
 import { GameStateManager } from './manager';
 import { meshService } from '../mesh-service';
-
-function seededRandom(seed: number) {
-  return () => {
-    seed = (seed * 16807) % 2147483647;
-    return (seed - 1) / 2147483646;
-  };
-}
+import { defaultNationInputs } from '../test-utils/nations';
 
 test('world generation assigns contiguous balanced territories with infrastructure', async () => {
   const meshData = await meshService.getMeshData('small');
@@ -20,10 +14,8 @@ test('world generation assigns contiguous balanced territories with infrastructu
 
   const gameId = 'g' + Math.random().toString(36).slice(2,8);
   const joinCode = 'J' + Math.random().toString(36).slice(2,7).toUpperCase();
-  const originalRandom = Math.random;
-  Math.random = seededRandom(8);
-  await GameService.createGame(gameId, joinCode, 'small', cellCount, 2, biomes);
-  Math.random = originalRandom;
+  const nations = defaultNationInputs(2);
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, nations, biomes, 'eta');
 
   const state = await GameService.getGameState(gameId);
   if (!state) throw new Error('state missing');

--- a/server/src/routes/createGame.ts
+++ b/server/src/routes/createGame.ts
@@ -2,13 +2,13 @@
 import { CORS_HEADERS, MAP_SIZES, MAX_BIOME_ID, MAX_NATIONS } from "../constants";
 import { GameService } from "../game-state";
 import { encode } from "../serialization";
-import type { MapSize } from "../types";
+import type { MapSize, NationCreationInput, NationPreset } from "../types";
 
 /**
  * Supported biome data formats for terrain upload
  */
 const SUPPORTED_CONTENT_TYPES = [
-  'application/octet-stream',  // Raw binary Uint8Array
+  'application/json',
 ] as const;
 
 /**
@@ -16,14 +16,48 @@ const SUPPORTED_CONTENT_TYPES = [
  */
 export async function createGame(req: Request) {
   try {
-    // Get cell count and map size from headers
-    const cellCount = parseInt(req.headers.get("x-cell-count") || "0");
-    const mapSizeHeader = (req.headers.get("x-map-size") as MapSize) || "xl";
-    const nationCount = parseInt(req.headers.get("x-nation-count") || "0");
-    const contentType = req.headers.get("content-type") || "application/octet-stream";
+    const contentType = req.headers.get("content-type") || "application/json";
 
-    // Validate inputs
-    if (!cellCount || cellCount <= 0) {
+    if (!SUPPORTED_CONTENT_TYPES.some(type => contentType.includes(type))) {
+      return new Response(
+        JSON.stringify({
+          error: "Unsupported content type",
+          supportedTypes: SUPPORTED_CONTENT_TYPES,
+          received: contentType,
+        }),
+        {
+          status: 415,
+          headers: {
+            "Content-Type": "application/json",
+            ...CORS_HEADERS,
+          },
+        }
+      );
+    }
+
+    let payload: any;
+    try {
+      payload = await req.json();
+    } catch (error: any) {
+      return new Response(
+        JSON.stringify({ error: "Invalid JSON payload", details: error?.message }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            ...CORS_HEADERS,
+          },
+        }
+      );
+    }
+
+    const mapSize = (payload.mapSize || "xl") as MapSize;
+    const cellCount = Number(payload.cellCount ?? (Array.isArray(payload.biomes) ? payload.biomes.length : 0));
+    const biomesInput = payload.biomes;
+    const nationsInput = payload.nations as Array<{ name: string; preset: string }> | undefined;
+    const seed = payload.seed;
+
+    if (!Number.isFinite(cellCount) || cellCount <= 0) {
       return new Response(JSON.stringify({ error: "Invalid cell count" }), {
         status: 400,
         headers: {
@@ -33,7 +67,92 @@ export async function createGame(req: Request) {
       });
     }
 
-    if (!nationCount || nationCount <= 0 || nationCount > MAX_NATIONS) {
+    if (!MAP_SIZES.includes(mapSize)) {
+      return new Response(
+        JSON.stringify({
+          error: "Invalid map size",
+          validSizes: MAP_SIZES,
+          received: mapSize,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            ...CORS_HEADERS,
+          },
+        }
+      );
+    }
+
+    if (!Array.isArray(biomesInput)) {
+      return new Response(
+        JSON.stringify({ error: "Biomes must be an array of integers" }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            ...CORS_HEADERS,
+          },
+        }
+      );
+    }
+
+    const biomes = new Uint8Array(biomesInput.length);
+    for (let i = 0; i < biomesInput.length; i++) {
+      const value = Number(biomesInput[i]);
+      if (!Number.isFinite(value) || value < 0 || value > MAX_BIOME_ID) {
+        return new Response(
+          JSON.stringify({
+            error: "Invalid biome values detected",
+            index: i,
+            maxValue: MAX_BIOME_ID,
+          }),
+          {
+            status: 400,
+            headers: {
+              "Content-Type": "application/json",
+              ...CORS_HEADERS,
+            },
+          }
+        );
+      }
+      biomes[i] = value;
+    }
+
+    if (biomes.length !== cellCount) {
+      return new Response(
+        JSON.stringify({
+          error: "Biome data length mismatch",
+          expected: cellCount,
+          received: biomes.length,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            ...CORS_HEADERS,
+          },
+        }
+      );
+    }
+
+    if (!Array.isArray(nationsInput) || nationsInput.length < 2) {
+      return new Response(
+        JSON.stringify({
+          error: "At least two nations are required",
+          min: 2,
+        }),
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            ...CORS_HEADERS,
+          },
+        }
+      );
+    }
+
+    if (nationsInput.length > MAX_NATIONS) {
       return new Response(
         JSON.stringify({ error: "Invalid nation count", max: MAX_NATIONS }),
         {
@@ -46,108 +165,47 @@ export async function createGame(req: Request) {
       );
     }
 
-    if (!MAP_SIZES.includes(mapSizeHeader)) {
-      return new Response(
-        JSON.stringify({
-          error: "Invalid map size",
-          validSizes: MAP_SIZES,
-          received: mapSizeHeader,
-        }),
-        {
-          status: 400,
-          headers: {
-            "Content-Type": "application/json",
-            ...CORS_HEADERS,
-          },
-        }
-      );
-    }
+    const errors: Array<{ index: number; field: 'name' | 'preset'; message: string }> = [];
+    const nameSet = new Map<string, number>();
+    const duplicateFirst = new Set<number>();
+    const nationInputs: NationCreationInput[] = nationsInput.map((nation, index) => {
+      const trimmedName = (nation.name ?? '').toString().trim();
+      const preset = nation.preset as NationPreset;
 
-    // Validate content type
-    if (!SUPPORTED_CONTENT_TYPES.includes(contentType as any)) {
-      return new Response(
-        JSON.stringify({
-          error: "Unsupported content type for biome data",
-          supportedTypes: SUPPORTED_CONTENT_TYPES,
-          received: contentType
-        }),
-        {
-          status: 415, // Unsupported Media Type
-          headers: {
-            "Content-Type": "application/json",
-            ...CORS_HEADERS,
-          },
+      if (trimmedName.length === 0) {
+        errors.push({ index, field: 'name', message: 'Name is required' });
+      } else {
+        const key = trimmedName.toLowerCase();
+        if (nameSet.has(key)) {
+          errors.push({ index, field: 'name', message: 'Name must be unique' });
+          const firstIndex = nameSet.get(key)!;
+          if (!duplicateFirst.has(firstIndex)) {
+            errors.push({ index: firstIndex, field: 'name', message: 'Name must be unique' });
+            duplicateFirst.add(firstIndex);
+          }
+        } else {
+          nameSet.set(key, index);
         }
-      );
-    }
-
-    // Parse biome data based on content type
-    let biomes: Uint8Array;
-    
-    try {
-      switch (contentType) {
-        case 'application/octet-stream':
-          // Raw binary data - should already be Uint8Array
-          const arrayBuffer = await req.arrayBuffer();
-          biomes = new Uint8Array(arrayBuffer);
-          break;
-          
-        default:
-          throw new Error(`Unsupported content type: ${contentType}`);
       }
-    } catch (parseError: any) {
-      return new Response(
-        JSON.stringify({
-          error: "Failed to parse biome data",
-          contentType,
-          details: parseError.message,
-          hint: "Ensure data format matches content-type header"
-        }),
-        {
-          status: 400,
-          headers: {
-            "Content-Type": "application/json",
-            ...CORS_HEADERS,
-          },
-        }
-      );
-    }
 
-    // Validate biome data length
-    if (biomes.length !== cellCount) {
-      return new Response(
-        JSON.stringify({
-          error: "Biome data length mismatch",
-          expected: cellCount,
-          received: biomes.length,
-          hint: "Biome array length must match x-cell-count header"
-        }),
-        {
-          status: 400,
-          headers: {
-            "Content-Type": "application/json",
-            ...CORS_HEADERS,
-          },
-        }
+      const presetValid = (
+        preset === 'Industrializing Exporter' ||
+        preset === 'Agrarian Surplus' ||
+        preset === 'Finance and Services Hub' ||
+        preset === 'Research State' ||
+        preset === 'Defense-Manufacturing Complex' ||
+        preset === 'Balanced Mixed Economy'
       );
-    }
-
-    // Validate biome values are in valid range (0-MAX_BIOME_ID)
-    const invalidIndices: number[] = [];
-    for (let i = 0; i < biomes.length && invalidIndices.length < 5; i++) {
-      if (biomes[i] > MAX_BIOME_ID) {
-        invalidIndices.push(i);
+      if (!presetValid) {
+        errors.push({ index, field: 'preset', message: 'Preset must be selected' });
       }
-    }
-    
-    if (invalidIndices.length > 0) {
+
+      return { name: trimmedName, preset: presetValid ? preset : 'Industrializing Exporter' };
+    });
+
+    if (errors.length > 0) {
       return new Response(
-        JSON.stringify({
-          error: "Invalid biome values detected",
-          invalidIndices: invalidIndices.slice(0, 5),
-          maxValue: MAX_BIOME_ID,
-          hint: `All biome values must be 0-${MAX_BIOME_ID}`
-        }),
+        JSON.stringify({ error: 'Invalid nation configuration', errors }),
         {
           status: 400,
           headers: {
@@ -166,14 +224,15 @@ export async function createGame(req: Request) {
     const game = await GameService.createGame(
       gameId,
       joinCode,
-      mapSizeHeader,
+      mapSize,
       cellCount,
-      nationCount,
-      biomes
+      nationInputs,
+      biomes,
+      seed
     );
 
     console.log(
-      `Created game ${gameId} with join code ${joinCode} (${mapSizeHeader}, ${cellCount} cells, ${contentType})`
+      `Created game ${gameId} with join code ${joinCode} (${mapSize}, ${cellCount} cells, ${contentType})`
     );
 
     const body = encode({

--- a/server/src/routes/input-validation.test.ts
+++ b/server/src/routes/input-validation.test.ts
@@ -3,13 +3,15 @@ import { GameService } from '../game-state';
 import { submitPlan } from './submitPlan';
 import { advanceTurn } from './advanceTurn';
 import type { TurnPlan } from '../types';
+import { defaultNationInputs } from '../test-utils/nations';
 
 async function setupGame() {
   const cellCount = 833;
   const biomes = new Uint8Array(cellCount).fill(1);
   const gameId = 'g' + Math.random().toString(36).slice(2,8);
   const joinCode = 'J' + Math.random().toString(36).slice(2,7).toUpperCase();
-  await GameService.createGame(gameId, joinCode, 'small', cellCount, 2, biomes);
+  const nations = defaultNationInputs(2);
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, nations, biomes);
   await GameService.joinGame(joinCode);
   await GameService.startGame(gameId);
   return { gameId };

--- a/server/src/routes/lifecycle.test.ts
+++ b/server/src/routes/lifecycle.test.ts
@@ -9,6 +9,7 @@ import { endGame } from './endGame';
 import { getGameState } from './getGameState';
 import { TurnManager } from '../turn';
 import { totalLabor, EDUCATION_TIERS, HEALTHCARE_TIERS } from '../welfare/manager';
+import { defaultNationInputs } from '../test-utils/nations';
 
 async function setupGame() {
   const cellCount = 833;
@@ -16,7 +17,8 @@ async function setupGame() {
   const biomes = new Uint8Array(cellCount).fill(1);
   const gameId = 'g' + Math.random().toString(36).slice(2,8);
   const joinCode = 'J' + Math.random().toString(36).slice(2,7).toUpperCase();
-  await GameService.createGame(gameId, joinCode, 'small', cellCount, 2, biomes);
+  const nations = defaultNationInputs(2);
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, nations, biomes);
   await GameService.joinGame(joinCode);
   await GameService.startGame(gameId);
   return { gameId, joinCode };

--- a/server/src/routes/startGame.lobby.test.ts
+++ b/server/src/routes/startGame.lobby.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { createGame } from './createGame';
 import { startGame } from './startGame';
 import { GameService } from '../game-state';
+import { defaultNationInputs } from '../test-utils/nations';
 
 // verify that game cannot start until required players have joined
 
@@ -10,12 +11,14 @@ test('startGame requires all nation slots filled', async () => {
   const req = new Request('http://localhost', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/octet-stream',
-      'X-Cell-Count': '4',
-      'X-Map-Size': 'small',
-      'X-Nation-Count': '2'
+      'Content-Type': 'application/json',
     },
-    body: biomes
+    body: JSON.stringify({
+      mapSize: 'small',
+      cellCount: 4,
+      biomes: Array.from(biomes),
+      nations: defaultNationInputs(2),
+    }),
   });
 
   const res = await createGame(req);

--- a/server/src/routes/systems.test.ts
+++ b/server/src/routes/systems.test.ts
@@ -14,6 +14,7 @@ import { getInfrastructure } from './getInfrastructure';
 import { getFinance } from './getFinance';
 import { getTrade } from './getTrade';
 import { getWelfare } from './getWelfare';
+import { defaultNationInputs } from '../test-utils/nations';
 
 async function setupGame() {
   const cellCount = 833;
@@ -21,7 +22,8 @@ async function setupGame() {
   const biomes = new Uint8Array(cellCount).fill(1);
   const gameId = 'g' + Math.random().toString(36).slice(2,8);
   const joinCode = 'J' + Math.random().toString(36).slice(2,7).toUpperCase();
-  await GameService.createGame(gameId, joinCode, 'small', cellCount, 2, biomes);
+  const nations = defaultNationInputs(2);
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, nations, biomes);
   await GameService.joinGame(joinCode);
   await GameService.startGame(gameId);
   return { gameId };

--- a/server/src/status/index.ts
+++ b/server/src/status/index.ts
@@ -1,0 +1,1 @@
+export { computeNationStatusSummary, createEmptyStatusSummary, updateNationStatus } from './summary';

--- a/server/src/status/summary.test.ts
+++ b/server/src/status/summary.test.ts
@@ -1,0 +1,179 @@
+import { expect, test, describe } from 'bun:test';
+import { GameStateManager } from '../game-state/manager';
+import { InMediaResInitializer } from '../game-state/inmediares';
+import { buildNationInputs } from '../test-utils/nations';
+import { computeNationStatusSummary, updateNationStatus } from './summary';
+import type { NationPreset, NationState } from '../types';
+
+const NEIGHBORS = new Int32Array([
+  1, 2,
+  0, 3,
+  0, 3,
+  1, 2,
+]);
+
+const OFFSETS = new Uint32Array([0, 2, 4, 6, 8]);
+
+const BIOMES = new Uint8Array([1, 7, 1, 1]);
+
+function initializeGame(presets: NationPreset[], seed = 'status-test') {
+  const players = presets.map((_, index) => `player${index + 1}`);
+  const biomes = new Uint8Array(BIOMES);
+  const game = GameStateManager.createCompleteGame(
+    `game-${seed}`,
+    `JOIN-${seed}`,
+    players,
+    'small',
+    biomes,
+    players.length,
+    [],
+    seed,
+  );
+
+  const nationInputs = buildNationInputs(presets);
+
+  players.forEach((playerId, index) => {
+    const cell = index === 0 ? 0 : index === 1 ? 2 : 3;
+    game.state.playerCells[playerId] = [cell];
+    game.state.cellOwnership[cell] = playerId;
+  });
+
+  GameStateManager.initializeNationInfrastructure(
+    game.state,
+    players,
+    biomes,
+    NEIGHBORS,
+    OFFSETS,
+  );
+
+  InMediaResInitializer.initialize(
+    game,
+    nationInputs,
+    biomes,
+    NEIGHBORS,
+    OFFSETS,
+    seed,
+  );
+
+  return { game, players };
+}
+
+function firstNation(game: { state: { nations: Record<string, NationState> } }, players: string[]) {
+  const playerId = players[0];
+  return { nation: game.state.nations[playerId], playerId };
+}
+
+describe('nation status summary', () => {
+  test('stockpiled resource deltas reflect production and consumption changes', () => {
+    const { game, players } = initializeGame(['Balanced Mixed Economy']);
+    const { nation } = firstNation(game, players);
+
+    const initial = computeNationStatusSummary(nation);
+    expect(initial.stockpiles.food.current).toBe(nation.stockpiles.food);
+
+    const originalFoodDelta = initial.stockpiles.food.delta;
+
+    if (nation.sectors.agriculture) {
+      nation.sectors.agriculture.utilization = Math.max(0, (nation.sectors.agriculture.utilization ?? 0) - 2);
+    }
+
+    const afterReduction = computeNationStatusSummary(nation);
+    expect(afterReduction.stockpiles.food.delta).toBeLessThanOrEqual(originalFoodDelta);
+
+    if (nation.sectors.agriculture) {
+      nation.sectors.agriculture.utilization = (nation.sectors.agriculture.utilization ?? 0) + 4;
+    }
+
+    const boosted = computeNationStatusSummary(nation);
+    expect(boosted.stockpiles.food.delta).toBeGreaterThan(afterReduction.stockpiles.food.delta);
+
+    if (nation.sectors.manufacturing) {
+      nation.sectors.manufacturing.utilization = (nation.sectors.manufacturing.utilization ?? 0) + 3;
+    }
+
+    const withManufacturing = computeNationStatusSummary(nation);
+    expect(withManufacturing.stockpiles.materials.delta).toBeLessThanOrEqual(boosted.stockpiles.materials.delta);
+  });
+
+  test('flows, labor availability, and happiness indicators update together', () => {
+    const { game, players } = initializeGame(['Research State']);
+    const { nation } = firstNation(game, players);
+
+    const status = computeNationStatusSummary(nation);
+    expect(status.flows.energy).toBeCloseTo(nation.energy.supply, 2);
+    expect(status.flows.logistics).toBeCloseTo(nation.logistics.supply, 2);
+
+    const researchSlots = nation.sectors.research?.utilization ?? 0;
+    expect(status.flows.research).toBeCloseTo(researchSlots, 2);
+
+    expect(status.labor.general).toBe(nation.labor.available.general);
+    expect(status.labor.skilled).toBe(nation.labor.available.skilled);
+    expect(status.labor.specialist).toBe(nation.labor.available.specialist);
+
+    nation.labor.happiness = 0.82;
+    const happy = computeNationStatusSummary(nation);
+    expect(happy.happiness.emoji).toBe('🙂');
+    expect(happy.happiness.value).toBe(Math.round(0.82 * 100));
+
+    nation.labor.happiness = 0.25;
+    const unhappy = computeNationStatusSummary(nation);
+    expect(unhappy.happiness.emoji).toBe('☹️');
+  });
+
+  test('gold indicator encodes debt as negative and respects mutual exclusivity', () => {
+    const { game, players } = initializeGame(['Finance and Services Hub']);
+    const { nation } = firstNation(game, players);
+
+    nation.finance.treasury = 75;
+    nation.finance.debt = 0;
+    let status = computeNationStatusSummary(nation);
+    expect(status.gold.isDebt).toBe(false);
+    expect(status.gold.value).toBeCloseTo(75, 2);
+
+    nation.finance.debt = 40;
+    nation.finance.treasury = 120;
+    status = computeNationStatusSummary(nation);
+    expect(status.gold.isDebt).toBe(true);
+    expect(status.gold.value).toBe(-40);
+
+    nation.finance.debt = 0;
+    nation.finance.treasury = 0;
+    status = computeNationStatusSummary(nation);
+    expect(status.gold.isDebt).toBe(false);
+    expect(status.gold.value).toBe(0);
+  });
+
+  test('status summaries are deterministic with identical seeds', () => {
+    const first = initializeGame(['Balanced Mixed Economy', 'Defense-Manufacturing Complex'], 'seed-a');
+    const second = initializeGame(['Balanced Mixed Economy', 'Defense-Manufacturing Complex'], 'seed-a');
+
+    first.players.forEach((playerId, index) => {
+      const nationA = first.game.state.nations[playerId];
+      const nationB = second.game.state.nations[second.players[index]];
+      expect(nationA.status).toEqual(nationB.status);
+    });
+  });
+
+  test('different presets produce distinct status emphases', () => {
+    const { game, players } = initializeGame([
+      'Industrializing Exporter',
+      'Agrarian Surplus',
+      'Finance and Services Hub',
+    ], 'variance');
+
+    const statuses = players.map((playerId) => game.state.nations[playerId].status);
+    const materialDeltas = statuses.map((status) => status.stockpiles.materials.delta);
+    const uniqueMaterialDeltas = new Set(materialDeltas.map((value) => Math.round(value * 100))); // quantize
+    expect(uniqueMaterialDeltas.size).toBeGreaterThan(1);
+  });
+
+  test('updateNationStatus mutates the nation and stays in sync', () => {
+    const { game, players } = initializeGame(['Balanced Mixed Economy']);
+    const { nation } = firstNation(game, players);
+
+    nation.finance.debt = 10;
+    const updated = updateNationStatus(nation);
+    expect(nation.status).toEqual(updated);
+    expect(updated.gold.value).toBe(-10);
+  });
+});

--- a/server/src/status/summary.test.ts
+++ b/server/src/status/summary.test.ts
@@ -131,7 +131,7 @@ describe('nation status summary', () => {
     expect(status.gold.value).toBeCloseTo(75, 2);
 
     nation.finance.debt = 40;
-    nation.finance.treasury = 120;
+    nation.finance.treasury = 0;
     status = computeNationStatusSummary(nation);
     expect(status.gold.isDebt).toBe(true);
     expect(status.gold.value).toBe(-40);

--- a/server/src/status/summary.ts
+++ b/server/src/status/summary.ts
@@ -1,0 +1,129 @@
+import { SECTOR_BASE_OUTPUT, SLOT_REQUIREMENTS } from '../economy';
+import type {
+  LaborPool,
+  NationState,
+  NationStatusSummary,
+  ResourceDeltaSnapshot,
+  ResourceType,
+  SectorType,
+} from '../types';
+
+const STOCK_KEYS = ['fx', 'food', 'ordnance', 'production', 'luxury', 'materials'] as const;
+type StockKey = (typeof STOCK_KEYS)[number];
+
+const HAPPY_THRESHOLD = 0.75;
+const CONTENT_THRESHOLD = 0.4;
+
+function cloneLabor(pool: LaborPool): LaborPool {
+  return {
+    general: pool?.general ?? 0,
+    skilled: pool?.skilled ?? 0,
+    specialist: pool?.specialist ?? 0,
+  };
+}
+
+export function createEmptyStatusSummary(): NationStatusSummary {
+  const zero: ResourceDeltaSnapshot = { current: 0, delta: 0 };
+  return {
+    gold: { value: 0, isDebt: false },
+    stockpiles: {
+      fx: { ...zero },
+      food: { ...zero },
+      ordnance: { ...zero },
+      production: { ...zero },
+      luxury: { ...zero },
+      materials: { ...zero },
+    },
+    flows: { energy: 0, logistics: 0, research: 0 },
+    labor: { general: 0, skilled: 0, specialist: 0 },
+    happiness: { value: 0, emoji: '😐' },
+  };
+}
+
+function sectorUtilization(nation: NationState, sector: SectorType): number {
+  const state = nation.sectors?.[sector];
+  if (!state) return 0;
+  if (typeof state.utilization === 'number') return state.utilization;
+  if (typeof state.funded === 'number') return state.funded;
+  return 0;
+}
+
+function happinessEmoji(value: number): string {
+  if (value >= HAPPY_THRESHOLD) return '🙂';
+  if (value >= CONTENT_THRESHOLD) return '😐';
+  return '☹️';
+}
+
+export function computeNationStatusSummary(nation: NationState): NationStatusSummary {
+  const produced: Partial<Record<ResourceType, number>> = {};
+  const consumed: Partial<Record<ResourceType, number>> = {};
+
+  (Object.keys(nation.sectors || {}) as SectorType[]).forEach((sector) => {
+    const active = sectorUtilization(nation, sector);
+    if (active <= 0) return;
+
+    const outputs = SECTOR_BASE_OUTPUT[sector];
+    if (outputs) {
+      for (const [resource, amount] of Object.entries(outputs)) {
+        produced[resource as ResourceType] =
+          (produced[resource as ResourceType] ?? 0) + active * (amount ?? 0);
+      }
+    }
+
+    const requirements = SLOT_REQUIREMENTS[sector];
+    if (requirements?.inputs) {
+      for (const [resource, amount] of Object.entries(requirements.inputs)) {
+        consumed[resource as ResourceType] =
+          (consumed[resource as ResourceType] ?? 0) + active * (amount ?? 0);
+      }
+    }
+  });
+
+  const laborConsumption = nation.labor?.consumption;
+  if (laborConsumption) {
+    consumed.food = (consumed.food ?? 0) + (laborConsumption.foodProvided ?? laborConsumption.foodRequired ?? 0);
+    consumed.luxury =
+      (consumed.luxury ?? 0) + (laborConsumption.luxuryProvided ?? laborConsumption.luxuryRequired ?? 0);
+  }
+
+  const stockpiles: NationStatusSummary['stockpiles'] = {
+    fx: { current: nation.stockpiles?.fx ?? 0, delta: 0 },
+    food: { current: nation.stockpiles?.food ?? 0, delta: 0 },
+    ordnance: { current: nation.stockpiles?.ordnance ?? 0, delta: 0 },
+    production: { current: nation.stockpiles?.production ?? 0, delta: 0 },
+    luxury: { current: nation.stockpiles?.luxury ?? 0, delta: 0 },
+    materials: { current: nation.stockpiles?.materials ?? 0, delta: 0 },
+  };
+
+  STOCK_KEYS.forEach((key) => {
+    const output = produced[key as ResourceType] ?? 0;
+    const input = consumed[key as ResourceType] ?? 0;
+    const delta = Math.round((output - input) * 100) / 100;
+    stockpiles[key].delta = delta;
+  });
+
+  const debt = nation.finance?.debt ?? 0;
+  const treasury = nation.finance?.treasury ?? 0;
+  const goldValue = debt > 0 ? -Math.abs(debt) : treasury;
+
+  const happinessRaw = nation.labor?.happiness ?? 0;
+  const happinessValue = Math.round(happinessRaw * 100);
+
+  return {
+    gold: { value: Math.round(goldValue * 100) / 100, isDebt: debt > 0 },
+    stockpiles,
+    flows: {
+      energy: Math.round((nation.energy?.supply ?? 0) * 100) / 100,
+      logistics: Math.round((nation.logistics?.supply ?? 0) * 100) / 100,
+      research: Math.round((produced.research ?? 0) * 100) / 100,
+    },
+    labor: cloneLabor(nation.labor?.available ?? { general: 0, skilled: 0, specialist: 0 }),
+    happiness: { value: happinessValue, emoji: happinessEmoji(happinessRaw) },
+  };
+}
+
+export function updateNationStatus(nation: NationState): NationStatusSummary {
+  const status = computeNationStatusSummary(nation);
+  nation.status = status;
+  return status;
+}

--- a/server/src/test-utils/nations.ts
+++ b/server/src/test-utils/nations.ts
@@ -1,0 +1,28 @@
+import type { NationCreationInput, NationPreset } from '../types';
+
+const PRESET_ORDER: NationPreset[] = [
+  'Industrializing Exporter',
+  'Agrarian Surplus',
+  'Finance and Services Hub',
+  'Research State',
+  'Defense-Manufacturing Complex',
+  'Balanced Mixed Economy',
+];
+
+export function buildNationInputs(presets: NationPreset[]): NationCreationInput[] {
+  return presets.map((preset, index) => ({
+    name: `Nation ${index + 1} (${preset})`,
+    preset,
+  }));
+}
+
+export function defaultNationInputs(count: number): NationCreationInput[] {
+  const inputs: NationCreationInput[] = [];
+  for (let i = 0; i < count; i++) {
+    inputs.push({
+      name: `Nation ${i + 1}`,
+      preset: PRESET_ORDER[i % PRESET_ORDER.length],
+    });
+  }
+  return inputs;
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -3,6 +3,25 @@ export type PlayerId = string;
 export type CellId = number;
 export type EntityId = number;
 
+export type NationPreset =
+  | "Industrializing Exporter"
+  | "Agrarian Surplus"
+  | "Finance and Services Hub"
+  | "Research State"
+  | "Defense-Manufacturing Complex"
+  | "Balanced Mixed Economy";
+
+export interface NationMeta {
+  id: PlayerId;
+  name: string;
+  preset: NationPreset;
+}
+
+export interface NationCreationInput {
+  name: string;
+  preset: NationPreset;
+}
+
 export type EntityType = 
   | "unit";
 
@@ -147,6 +166,101 @@ export interface SectorState {
   idle: number;
   /** Slots that actually ran after all gates */
   utilization?: number;
+}
+
+export interface NationEnergySnapshot {
+  supply: number;
+  demand: number;
+  ratio: number;
+  plants: PlantRegistryEntry[];
+  throttledSectors: Partial<Record<SectorType, number>>;
+}
+
+export interface NationLogisticsSnapshot {
+  supply: number;
+  demand: number;
+  ratio: number;
+  slots: number;
+  throttledSectors: Partial<Record<SectorType, number>>;
+}
+
+export interface NationWelfareSnapshot {
+  education: number;
+  healthcare: number;
+  socialSupport: number;
+  cost: number;
+  autoDownshifted: boolean;
+}
+
+export interface NationFinanceWaterfall {
+  initial: number;
+  interest: number;
+  operations: number;
+  welfare: number;
+  military: number;
+  projects: number;
+  surplus: number;
+}
+
+export interface NationFinanceSnapshot {
+  treasury: number;
+  stableRevenue: number;
+  creditLimit: number;
+  debt: number;
+  interest: number;
+  waterfall: NationFinanceWaterfall;
+}
+
+export interface NationLaborSnapshot {
+  available: LaborPool;
+  assigned: LaborPool;
+  lai: number;
+  happiness: number;
+  consumption: LaborConsumption;
+}
+
+export interface NationStockpileSnapshot {
+  food: number;
+  fuel: number;
+  materials: number;
+  fx: number;
+  luxury: number;
+  ordnance: number;
+  production: number;
+}
+
+export interface NationMilitarySnapshot {
+  upkeep: number;
+  funded: number;
+  discretionary: number;
+}
+
+export interface NationProjectSnapshot {
+  id: number;
+  sector: SectorType;
+  tier: ProjectTier;
+  turnsRemaining: number;
+  delayed: boolean;
+}
+
+export interface NationState {
+  id: PlayerId;
+  name: string;
+  preset: NationPreset;
+  canton: string;
+  coastal: boolean;
+  signature: string;
+  energy: NationEnergySnapshot;
+  logistics: NationLogisticsSnapshot;
+  welfare: NationWelfareSnapshot;
+  finance: NationFinanceSnapshot;
+  labor: NationLaborSnapshot;
+  stockpiles: NationStockpileSnapshot;
+  military: NationMilitarySnapshot;
+  sectors: Partial<Record<SectorType, SectorState>>;
+  projects: NationProjectSnapshot[];
+  idleCost: number;
+  omCost: number;
 }
 
 // === Energy System Types ===
@@ -374,6 +488,12 @@ export interface GameMeta {
    */
   players: PlayerId[];
 
+  /** Display metadata for each nation configured at creation */
+  nations: NationMeta[];
+
+  /** Optional reproducibility seed provided at game creation */
+  seed?: string | null;
+
   /**
    * Size of the map for this game.
    * Determines which mesh to use.
@@ -481,6 +601,9 @@ export interface GameState {
    * Incremented each time a new entity is created.
    */
   nextEntityId: number;
+
+  /** Per-nation initialization snapshots for in-media-res starts */
+  nations: Record<PlayerId, NationState>;
 }
 
 /**

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -219,6 +219,11 @@ export interface NationLaborSnapshot {
   consumption: LaborConsumption;
 }
 
+export interface ResourceDeltaSnapshot {
+  current: number;
+  delta: number;
+}
+
 export interface NationStockpileSnapshot {
   food: number;
   fuel: number;
@@ -227,6 +232,25 @@ export interface NationStockpileSnapshot {
   luxury: number;
   ordnance: number;
   production: number;
+}
+
+export interface NationStatusSummary {
+  gold: { value: number; isDebt: boolean };
+  stockpiles: {
+    fx: ResourceDeltaSnapshot;
+    food: ResourceDeltaSnapshot;
+    ordnance: ResourceDeltaSnapshot;
+    production: ResourceDeltaSnapshot;
+    luxury: ResourceDeltaSnapshot;
+    materials: ResourceDeltaSnapshot;
+  };
+  flows: {
+    energy: number;
+    logistics: number;
+    research: number;
+  };
+  labor: LaborPool;
+  happiness: { value: number; emoji: string };
 }
 
 export interface NationMilitarySnapshot {
@@ -261,6 +285,7 @@ export interface NationState {
   projects: NationProjectSnapshot[];
   idleCost: number;
   omCost: number;
+  status: NationStatusSummary;
 }
 
 // === Energy System Types ===

--- a/server/src/utils/random.ts
+++ b/server/src/utils/random.ts
@@ -1,0 +1,58 @@
+export class SeededRandom {
+  private state: number;
+
+  constructor(seed: string | number | null | undefined) {
+    this.state = SeededRandom.normalizeSeed(seed);
+  }
+
+  static normalizeSeed(seed: string | number | null | undefined): number {
+    if (seed === null || seed === undefined) {
+      return Math.floor(Math.random() * 0xffffffff) || 1;
+    }
+    if (typeof seed === 'number' && Number.isFinite(seed)) {
+      const n = seed % 0xffffffff;
+      return (n >>> 0) || 1;
+    }
+    const str = String(seed);
+    let hash = 2166136261;
+    for (let i = 0; i < str.length; i++) {
+      hash ^= str.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    return (hash >>> 0) || 1;
+  }
+
+  next(): number {
+    this.state = (Math.imul(this.state, 1664525) + 1013904223) >>> 0;
+    return this.state / 0xffffffff;
+  }
+
+  nextInt(max: number): number {
+    if (max <= 0) return 0;
+    return Math.floor(this.next() * max);
+  }
+
+  nextRange(min: number, max: number): number {
+    if (max <= min) return min;
+    return min + this.next() * (max - min);
+  }
+
+  nextBoolean(): boolean {
+    return this.next() < 0.5;
+  }
+
+  pick<T>(items: readonly T[]): T {
+    if (items.length === 0) {
+      throw new Error('Cannot pick from empty collection');
+    }
+    return items[this.nextInt(items.length)];
+  }
+
+  shuffle<T>(array: T[]): T[] {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = this.nextInt(i + 1);
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+  }
+}

--- a/server/src/websocket/join-full-game.test.ts
+++ b/server/src/websocket/join-full-game.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import { GameService } from '../game-state';
 import { setupWebSocketHandler } from '../websocket';
 import { gameRooms, socketToGame } from '../index';
+import { defaultNationInputs } from '../test-utils/nations';
 
 test('joining player receives full game data on websocket connect', async () => {
   // create a small world and join a second player
@@ -9,7 +10,8 @@ test('joining player receives full game data on websocket connect', async () => 
   const biomes = new Uint8Array(cellCount).fill(1);
   const gameId = 'g' + Math.random().toString(36).slice(2, 8);
   const joinCode = 'J' + Math.random().toString(36).slice(2, 7).toUpperCase();
-  await GameService.createGame(gameId, joinCode, 'small', cellCount, 2, biomes);
+  const nations = defaultNationInputs(2);
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, nations, biomes);
   const joinRes = await GameService.joinGame(joinCode);
   if (!joinRes) throw new Error('join failed');
 

--- a/server/src/websocket/turn-events.test.ts
+++ b/server/src/websocket/turn-events.test.ts
@@ -4,6 +4,7 @@ import { submitPlan } from '../routes/submitPlan';
 import { advanceTurn } from '../routes/advanceTurn';
 import type { TurnPlan } from '../types';
 import { server } from '../index';
+import { defaultNationInputs } from '../test-utils/nations';
 
 const PORT = process.env.PORT || 3000;
 
@@ -13,7 +14,8 @@ async function setupGame() {
   const biomes = new Uint8Array(cellCount).fill(1);
   const gameId = 'g' + Math.random().toString(36).slice(2,8);
   const joinCode = 'J' + Math.random().toString(36).slice(2,7).toUpperCase();
-  await GameService.createGame(gameId, joinCode, 'small', cellCount, 2, biomes);
+  const nations = defaultNationInputs(2);
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, nations, biomes);
   await GameService.joinGame(joinCode);
   await GameService.startGame(gameId);
   const player2 = 'player2';

--- a/tests/clientServer.integration.test.ts
+++ b/tests/clientServer.integration.test.ts
@@ -26,24 +26,31 @@ test('client and server integrate on game creation', async () => {
     headers: {
       Origin: 'http://localhost:5173',
       'Access-Control-Request-Method': 'POST',
-      'Access-Control-Request-Headers': 'X-Nation-Count, Content-Type, X-Cell-Count, X-Map-Size',
+      'Access-Control-Request-Headers': 'Content-Type',
     },
   });
   expect(preflight.status).toBe(200);
-  expect(preflight.headers.get('Access-Control-Allow-Headers') || '').toContain('X-Nation-Count');
+  expect(preflight.headers.get('Access-Control-Allow-Headers') || '').toContain('Content-Type');
 
   // Create game request with biome data
   const cellCount = 4;
   const biomes = new Uint8Array([1,1,1,7]);
+  const nations = [
+    { name: 'Alpha', preset: 'Industrializing Exporter' },
+    { name: 'Beta', preset: 'Agrarian Surplus' },
+  ];
   const res = await fetch(`http://localhost:${PORT}/api/games/create`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/octet-stream',
-      'X-Cell-Count': String(cellCount),
-      'X-Map-Size': 'small',
-      'X-Nation-Count': '2',
+      'Content-Type': 'application/json',
     },
-    body: biomes,
+    body: JSON.stringify({
+      mapSize: 'small',
+      cellCount,
+      biomes: Array.from(biomes),
+      nations,
+      seed: 'integration-seed',
+    }),
   });
   expect(res.status).toBe(201);
   const body = await res.text();


### PR DESCRIPTION
## Summary
- add a deterministic in-media-res initializer that seeds nation sectors, stockpiles, finance, welfare, and projects while clamping energy/logistics ratios
- introduce a reusable SeededRandom helper and nation test builders, and update the createGame service/route plus client UI to pass structured nation payloads with seeds
- expand the automated test suite with initializer invariants, JSON route validation, integration coverage, and seed-repeatability checks

## Testing
- bun test server tests
- npm test --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68d4b35c0e948327a4b1df3e9bee03cb