### PR TITLE
Initialize multi-canton partitions for nations

### DIFF
--- a/server/src/game-state/authority.test.ts
+++ b/server/src/game-state/authority.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'bun:test';
+import { GameService } from './service';
+import { meshService } from '../mesh-service';
+import { defaultNationInputs } from '../test-utils/nations';
+import { auditGameIntegrity } from './authority';
+
+function uniqueId(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+test('authoritative snapshots remain coherent for consumer views', async () => {
+  const meshData = await meshService.getMeshData('small');
+  const cellCount = meshData.cellCount;
+  const biomes = new Uint8Array(cellCount).fill(1);
+  const nations = defaultNationInputs(3);
+  const gameId = uniqueId('auth');
+  const join = uniqueId('J').toUpperCase().slice(0, 6);
+
+  await GameService.createGame(gameId, join, 'small', cellCount, nations, biomes, 'authority-coherence');
+
+  const game = await GameService.getGame(gameId);
+  expect(game).not.toBeNull();
+  if (!game) throw new Error('game missing');
+
+  const coherenceIssues = auditGameIntegrity(game);
+  expect(coherenceIssues).toEqual([]);
+
+  const state = await GameService.getGameState(gameId);
+  const meta = await GameService.getGameMeta(gameId);
+  expect(state).not.toBeNull();
+  expect(meta).not.toBeNull();
+  if (!state || !meta) return;
+
+  expect(game.state).toEqual(state);
+  expect(game.meta.joinCode).toBe(meta.joinCode);
+  expect(game.meta.nationCount).toBe(meta.nationCount);
+});
+
+test('deterministic seeds produce identical authoritative states', async () => {
+  const meshData = await meshService.getMeshData('small');
+  const cellCount = meshData.cellCount;
+  const biomes = new Uint8Array(cellCount).fill(1);
+  const nations = defaultNationInputs(2);
+  const seed = 'determinism-check';
+
+  const idOne = uniqueId('det1');
+  const idTwo = uniqueId('det2');
+  const joinOne = uniqueId('J').toUpperCase().slice(0, 6);
+  const joinTwo = uniqueId('J').toUpperCase().slice(0, 6);
+
+  await GameService.createGame(idOne, joinOne, 'small', cellCount, nations, biomes, seed);
+  await GameService.createGame(idTwo, joinTwo, 'small', cellCount, nations, biomes, seed);
+
+  const stateOne = await GameService.getGameState(idOne);
+  const stateTwo = await GameService.getGameState(idTwo);
+  expect(stateOne).not.toBeNull();
+  expect(stateTwo).not.toBeNull();
+  if (!stateOne || !stateTwo) return;
+  expect(stateOne).toEqual(stateTwo);
+
+  const metaOne = await GameService.getGameMeta(idOne);
+  const metaTwo = await GameService.getGameMeta(idTwo);
+  expect(metaOne?.nationCount).toBe(metaTwo?.nationCount);
+  expect(metaOne?.seed).toBe(metaTwo?.seed);
+  expect(metaOne?.players.length).toBe(metaTwo?.players.length);
+});

--- a/server/src/game-state/authority.ts
+++ b/server/src/game-state/authority.ts
@@ -1,0 +1,237 @@
+import type { Game, GameMeta, GameMap, GameState, EntityId } from '../types';
+
+function clone<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  throw new Error('structuredClone is not available in this environment');
+}
+
+function deepFreeze<T>(value: T, seen = new WeakSet()): T {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return value;
+  }
+  if (value instanceof ArrayBuffer || value instanceof DataView) {
+    return value as T;
+  }
+  if (seen.has(value as object)) {
+    return value;
+  }
+  seen.add(value as object);
+  const propNames = Reflect.ownKeys(value as object);
+  for (const name of propNames) {
+    const desc = Object.getOwnPropertyDescriptor(value as object, name);
+    if (!desc || !('value' in desc)) continue;
+    deepFreeze(desc.value, seen);
+  }
+  return Object.freeze(value) as T;
+}
+
+export interface AuthoritativeSnapshot {
+  game: Readonly<Game>;
+  state: Readonly<GameState>;
+  meta: Readonly<GameMeta>;
+  map: Readonly<GameMap>;
+}
+
+export interface UpdateResult<T> extends AuthoritativeSnapshot {
+  result: T;
+}
+
+export function auditGameIntegrity(game: Game): string[] {
+  const issues: string[] = [];
+  const state = game.state;
+
+  const ownership = state.cellOwnership;
+  const playerCells = state.playerCells;
+
+  for (const [cellKey, owner] of Object.entries(ownership)) {
+    const cellId = Number(cellKey);
+    if (!playerCells[owner]?.includes(cellId)) {
+      issues.push(`Cell ${cellId} owned by ${owner} missing from playerCells.`);
+    }
+  }
+
+  for (const [playerId, cells] of Object.entries(playerCells)) {
+    for (const cell of cells) {
+      if (ownership[cell] !== playerId) {
+        issues.push(`Player ${playerId} lists cell ${cell} but ownership is ${ownership[cell] ?? 'none'}.`);
+      }
+    }
+  }
+
+  for (const [cantonId, cells] of Object.entries(state.cantonCells)) {
+    const meta = state.cantonMeta[cantonId];
+    if (!meta) {
+      issues.push(`Missing canton meta for ${cantonId}.`);
+    }
+    for (const cell of cells) {
+      if (state.cellCantons[cell] !== cantonId) {
+        issues.push(`Cell ${cell} lists canton ${state.cellCantons[cell]} but ${cantonId} includes it.`);
+      }
+    }
+  }
+
+  for (const [cellKey, cantonId] of Object.entries(state.cellCantons)) {
+    if (!cantonId) continue;
+    const cells = state.cantonCells[cantonId];
+    if (!cells || !cells.includes(Number(cellKey))) {
+      issues.push(`Cell ${cellKey} maps to canton ${cantonId} but cantonCells missing it.`);
+    }
+  }
+
+  const assignedCantons = new Set<string>();
+  for (const [playerId, cantons] of Object.entries(state.nationCantons)) {
+    for (const cantonId of cantons) {
+      if (!state.cantonCells[cantonId]) {
+        issues.push(`Nation ${playerId} references canton ${cantonId} with no cells.`);
+      }
+      assignedCantons.add(cantonId);
+    }
+  }
+
+  for (const cantonId of Object.keys(state.cantonCells)) {
+    if (!assignedCantons.has(cantonId)) {
+      issues.push(`Canton ${cantonId} is not assigned to any nation.`);
+    }
+  }
+
+  const entities = state.entities;
+  const cellEntities = state.cellEntities;
+  const playerEntities = state.playerEntities;
+  const typeEntities = state.entitiesByType;
+
+  for (const [entityId, entity] of Object.entries(entities)) {
+    const numericId = Number(entityId) as EntityId;
+    if (!cellEntities[entity.cellId]?.includes(numericId)) {
+      issues.push(`Entity ${entityId} missing from cellEntities for cell ${entity.cellId}.`);
+    }
+    if (entity.owner && !playerEntities[entity.owner]?.includes(numericId)) {
+      issues.push(`Entity ${entityId} owned by ${entity.owner} missing from playerEntities.`);
+    }
+    if (!typeEntities[entity.type as keyof typeof typeEntities]?.includes(numericId)) {
+      issues.push(`Entity ${entityId} missing from type index ${entity.type}.`);
+    }
+  }
+
+  for (const [cellKey, ids] of Object.entries(cellEntities)) {
+    for (const id of ids) {
+      const entity = entities[id];
+      if (!entity) {
+        issues.push(`cellEntities references missing entity ${id} on cell ${cellKey}.`);
+        continue;
+      }
+      if (entity.cellId !== Number(cellKey)) {
+        issues.push(`Entity ${id} stored on cell ${entity.cellId} but indexed for cell ${cellKey}.`);
+      }
+    }
+  }
+
+  for (const [playerId, ids] of Object.entries(playerEntities)) {
+    for (const id of ids) {
+      const entity = entities[id];
+      if (entity && entity.owner !== playerId) {
+        issues.push(`Player ${playerId} lists entity ${id} owned by ${entity.owner ?? 'none'}.`);
+      }
+    }
+  }
+
+  for (const [type, ids] of Object.entries(typeEntities)) {
+    for (const id of ids) {
+      const entity = entities[id];
+      if (!entity) {
+        issues.push(`Entity ${id} missing but referenced in type index ${type}.`);
+      }
+    }
+  }
+
+  for (const [nationId, nation] of Object.entries(state.nations)) {
+    if (nation.id !== nationId) {
+      issues.push(`Nation snapshot key ${nationId} mismatches embedded id ${nation.id}.`);
+    }
+  }
+
+  return issues;
+}
+
+export class AuthoritativeGameStore {
+  private readonly games = new Map<string, Game>();
+
+  register(game: Game): void {
+    this.games.set(game.meta.gameId, game);
+  }
+
+  has(gameId: string): boolean {
+    return this.games.has(gameId);
+  }
+
+  getMutableGame(gameId: string): Game | null {
+    return this.games.get(gameId) ?? null;
+  }
+
+  getSnapshot(gameId: string): AuthoritativeSnapshot | null {
+    const game = this.games.get(gameId);
+    if (!game) return null;
+    return {
+      game: deepFreeze(clone(game)),
+      state: deepFreeze(clone(game.state)),
+      meta: deepFreeze(clone(game.meta)),
+      map: deepFreeze(clone(game.map)),
+    };
+  }
+
+  getState(gameId: string): Readonly<GameState> | null {
+    const record = this.getSnapshot(gameId);
+    return record?.state ?? null;
+  }
+
+  getMeta(gameId: string): Readonly<GameMeta> | null {
+    const record = this.getSnapshot(gameId);
+    return record?.meta ?? null;
+  }
+
+  getGame(gameId: string): Readonly<Game> | null {
+    const record = this.getSnapshot(gameId);
+    return record?.game ?? null;
+  }
+
+  getMap(gameId: string): Readonly<GameMap> | null {
+    const record = this.getSnapshot(gameId);
+    return record?.map ?? null;
+  }
+
+  async update<T>(gameId: string, mutator: (game: Game) => T | Promise<T>): Promise<UpdateResult<T>> {
+    const game = this.games.get(gameId);
+    if (!game) {
+      throw new Error(`Game ${gameId} not found`);
+    }
+    const result = await mutator(game);
+    const issues = auditGameIntegrity(game);
+    if (issues.length) {
+      throw new Error(`Authoritative state violation:\n${issues.join('\n')}`);
+    }
+    const snapshot = this.getSnapshot(gameId);
+    if (!snapshot) {
+      throw new Error('Failed to capture authoritative snapshot');
+    }
+    return { ...snapshot, result };
+  }
+
+  listSnapshots(): AuthoritativeSnapshot[] {
+    const snapshots: AuthoritativeSnapshot[] = [];
+    for (const gameId of this.games.keys()) {
+      const snapshot = this.getSnapshot(gameId);
+      if (snapshot) snapshots.push(snapshot);
+    }
+    return snapshots;
+  }
+
+  get size(): number {
+    return this.games.size;
+  }
+}
+
+export const authoritativeStore = new AuthoritativeGameStore();

--- a/server/src/game-state/cantons.test.ts
+++ b/server/src/game-state/cantons.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from 'bun:test';
+import { GameService } from './service';
+import { meshService } from '../mesh-service';
+import { defaultNationInputs } from '../test-utils/nations';
+import { GameStateManager } from './manager';
+
+function isContiguous(cells: number[], neighbors: Int32Array, offsets: Uint32Array): boolean {
+  if (cells.length === 0) return true;
+  const owned = new Set(cells);
+  const visited = new Set<number>();
+  const queue: number[] = [cells[0]];
+  visited.add(cells[0]);
+  while (queue.length) {
+    const cell = queue.shift()!;
+    const start = offsets[cell];
+    const end = offsets[cell + 1];
+    for (let i = start; i < end; i++) {
+      const nb = neighbors[i];
+      if (nb >= 0 && owned.has(nb) && !visited.has(nb)) {
+        visited.add(nb);
+        queue.push(nb);
+      }
+    }
+  }
+  return visited.size === cells.length;
+}
+
+function hasCoastalCell(cells: number[], biomes: Uint8Array, neighbors: Int32Array, offsets: Uint32Array): boolean {
+  for (const cell of cells) {
+    const start = offsets[cell];
+    const end = offsets[cell + 1];
+    for (let i = start; i < end; i++) {
+      const nb = neighbors[i];
+      if (nb >= 0) {
+        const biome = biomes[nb];
+        if (biome === 6 || biome === 7) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function areaBounds(total: number, count: number): { min: number; max: number } {
+  const target = total / count;
+  const min = Math.floor(target * 0.75);
+  const max = Math.ceil(target * 1.25);
+  return { min: Math.max(1, min), max: Math.max(1, max) };
+}
+
+function sumAreas(cells: number[][]): number {
+  return cells.reduce((sum, group) => sum + group.length, 0);
+}
+
+test('initializeCantons partitions nations into balanced contiguous regions', async () => {
+  const meshData = await meshService.getMeshData('small');
+  const cellCount = meshData.cellCount;
+  const biomes = new Uint8Array(cellCount).fill(1);
+  biomes[0] = 7;
+  biomes[1] = 6;
+
+  const nations = defaultNationInputs(3);
+  const gameId = `cantons-${Math.random().toString(36).slice(2, 8)}`;
+  const joinCode = `J${Math.random().toString(36).slice(2, 7).toUpperCase()}`;
+
+  await GameService.createGame(gameId, joinCode, 'small', cellCount, nations, biomes, 'canton-test');
+  const state = await GameService.getGameState(gameId);
+  if (!state) throw new Error('state missing');
+
+  const neighbors = meshData.cellNeighbors;
+  const offsets = meshData.cellOffsets;
+
+  for (const playerId of Object.keys(state.playerCells)) {
+    const playerCells = GameStateManager.getPlayerCells(state, playerId);
+    const cantonIds = state.nationCantons[playerId] ?? [];
+    expect(cantonIds.length).toBeGreaterThan(0);
+
+    const cantonCellGroups = cantonIds.map((id) => state.cantonCells[id] ?? []);
+    expect(sumAreas(cantonCellGroups)).toBe(playerCells.length);
+
+    const { min, max } = areaBounds(playerCells.length, cantonIds.length);
+    const coastalRequired = hasCoastalCell(playerCells, biomes, neighbors, offsets);
+    let coastalCantons = 0;
+
+    for (const [index, cantonId] of cantonIds.entries()) {
+      const group = state.cantonCells[cantonId] ?? [];
+      expect(group.length).toBeGreaterThanOrEqual(min - 1);
+      expect(group.length).toBeLessThanOrEqual(max + 1);
+      expect(isContiguous(group, neighbors, offsets)).toBe(true);
+
+      const meta = state.cantonMeta[cantonId];
+      expect(meta).toBeDefined();
+      if (meta) {
+        expect(meta.area).toBe(group.length);
+        coastalCantons += meta.coastal ? 1 : 0;
+      }
+
+      for (const cell of group) {
+        expect(state.cellCantons[cell]).toBe(cantonId);
+      }
+
+      if (index === 0) {
+        expect(meta?.capital ?? false).toBe(true);
+      }
+    }
+
+    if (coastalRequired) {
+      expect(coastalCantons).toBeGreaterThan(0);
+    }
+  }
+});

--- a/server/src/game-state/cantons.ts
+++ b/server/src/game-state/cantons.ts
@@ -1,0 +1,409 @@
+import { EconomyManager } from '../economy';
+import type {
+  CantonTerritoryMeta,
+  CellId,
+  GameState,
+  NationPreset,
+  PlayerId,
+  TileType,
+} from '../types';
+
+interface BandConfig {
+  min: number;
+  max: number;
+  targetArea: number;
+}
+
+const MIN_CANTON_AREA = 30;
+
+const BIOME_TILE_MAP: Record<number, TileType> = {
+  0: 'plains',
+  1: 'woods',
+  2: 'rainforest',
+  3: 'wetlands',
+  4: 'hills',
+  5: 'mountains',
+  6: 'shallows',
+  7: 'coast',
+  8: 'tundra',
+  9: 'tundra',
+  10: 'tundra',
+  11: 'tundra',
+  12: 'desert',
+  13: 'desert',
+  14: 'desert',
+};
+
+function bandForPreset(preset: NationPreset): BandConfig {
+  switch (preset) {
+    case 'Finance and Services Hub':
+      return { min: 3, max: 4, targetArea: 85 };
+    case 'Research State':
+    case 'Balanced Mixed Economy':
+      return { min: 4, max: 6, targetArea: 75 };
+    case 'Industrializing Exporter':
+    case 'Defense-Manufacturing Complex':
+    case 'Agrarian Surplus':
+    default:
+      return { min: 6, max: 10, targetArea: 65 };
+  }
+}
+
+function determineCantonCount(total: number, preset: NationPreset): number {
+  const band = bandForPreset(preset);
+  if (total <= MIN_CANTON_AREA) {
+    return 1;
+  }
+  const maxByArea = Math.max(1, Math.floor(total / MIN_CANTON_AREA));
+  let desired = Math.round(total / band.targetArea);
+  desired = Math.max(band.min, Math.min(band.max, desired));
+  desired = Math.min(desired, maxByArea);
+  desired = Math.max(1, Math.min(desired, total));
+  if (desired < band.min && maxByArea >= band.min) {
+    desired = band.min;
+  }
+  if (desired === 1 && total >= MIN_CANTON_AREA * 2) {
+    desired = Math.min(Math.max(2, band.min), Math.min(band.max, maxByArea));
+  }
+  return desired;
+}
+
+function distanceSq(aX: number, aY: number, bX: number, bY: number): number {
+  const dx = aX - bX;
+  const dy = aY - bY;
+  return dx * dx + dy * dy;
+}
+
+function selectSeeds(
+  cells: CellId[],
+  coords: Float64Array,
+  k: number,
+  capital: CellId,
+  coastalCells: CellId[],
+): CellId[] {
+  if (k <= 1) return [capital];
+  const seeds: CellId[] = [capital];
+  const used = new Set<CellId>(seeds);
+  const cellCoords = (id: CellId) => [coords[2 * id], coords[2 * id + 1]] as const;
+
+  const chooseFarthest = (candidates: CellId[]): CellId | null => {
+    let best: CellId | null = null;
+    let bestDist = -1;
+    for (const cell of candidates) {
+      if (used.has(cell)) continue;
+      const [cx, cy] = cellCoords(cell);
+      let minDist = Infinity;
+      for (const seed of seeds) {
+        const [sx, sy] = cellCoords(seed);
+        const dist = distanceSq(cx, cy, sx, sy);
+        if (dist < minDist) {
+          minDist = dist;
+        }
+      }
+      if (minDist > bestDist + 1e-6 || (Math.abs(minDist - bestDist) <= 1e-6 && (best === null || cell < best))) {
+        bestDist = minDist;
+        best = cell;
+      }
+    }
+    return best;
+  };
+
+  if (coastalCells.length) {
+    const coastSeed = chooseFarthest(coastalCells);
+    if (coastSeed !== null) {
+      seeds.push(coastSeed);
+      used.add(coastSeed);
+    }
+  }
+
+  while (seeds.length < k) {
+    const next = chooseFarthest(cells);
+    if (next === null) break;
+    seeds.push(next);
+    used.add(next);
+  }
+
+  while (seeds.length < k) {
+    for (const cell of cells) {
+      if (!used.has(cell)) {
+        seeds.push(cell);
+        used.add(cell);
+      }
+      if (seeds.length === k) break;
+    }
+  }
+
+  return seeds.slice(0, k);
+}
+
+function buildAdjacency(
+  owned: Set<CellId>,
+  neighbors: Int32Array,
+  offsets: Uint32Array,
+): Map<CellId, CellId[]> {
+  const map = new Map<CellId, CellId[]>();
+  for (const cell of owned) {
+    const start = offsets[cell];
+    const end = offsets[cell + 1];
+    const list: CellId[] = [];
+    for (let i = start; i < end; i++) {
+      const nb = neighbors[i];
+      if (nb >= 0 && owned.has(nb)) {
+        list.push(nb);
+      }
+    }
+    map.set(cell, list);
+  }
+  return map;
+}
+
+function computeTargetSizes(total: number, k: number): number[] {
+  const base = Math.floor(total / k);
+  const remainder = total % k;
+  const targets = new Array(k).fill(base);
+  for (let i = 0; i < remainder; i++) {
+    targets[i] += 1;
+  }
+  return targets;
+}
+
+function partitionWithBalancedGrowth(
+  seeds: CellId[],
+  adjacency: Map<CellId, CellId[]>,
+  targets: number[],
+): Map<CellId, number> {
+  const assignment = new Map<CellId, number>();
+  const k = seeds.length;
+  const queues: CellId[][] = Array.from({ length: k }, () => []);
+  const queueSets: Array<Set<CellId>> = Array.from({ length: k }, () => new Set());
+  const sizes = new Array(k).fill(0);
+
+  const pushNeighbor = (idx: number, cell: CellId) => {
+    if (assignment.has(cell)) return;
+    const set = queueSets[idx];
+    if (set.has(cell)) return;
+    set.add(cell);
+    queues[idx].push(cell);
+  };
+
+  const popNeighbor = (idx: number): CellId | undefined => {
+    const queue = queues[idx];
+    const set = queueSets[idx];
+    while (queue.length) {
+      const cell = queue.shift()!;
+      if (assignment.has(cell)) {
+        set.delete(cell);
+        continue;
+      }
+      set.delete(cell);
+      return cell;
+    }
+    return undefined;
+  };
+
+  seeds.forEach((seed, idx) => {
+    assignment.set(seed, idx);
+    sizes[idx] = 1;
+    const neighbors = adjacency.get(seed) || [];
+    for (const nb of neighbors) {
+      pushNeighbor(idx, nb);
+    }
+  });
+
+  let assigned = assignment.size;
+  const total = adjacency.size;
+
+  const selectCanton = (allowOver: boolean): { idx: number; cell: CellId } | null => {
+    let bestIdx = -1;
+    let bestRatio = Infinity;
+    for (let idx = 0; idx < k; idx++) {
+      if (!allowOver && sizes[idx] >= targets[idx]) continue;
+      if (queues[idx].length === 0) continue;
+      const ratio = sizes[idx] / targets[idx];
+      if (ratio < bestRatio - 1e-9 || (Math.abs(ratio - bestRatio) <= 1e-9 && idx < bestIdx)) {
+        bestIdx = idx;
+        bestRatio = ratio;
+      }
+    }
+    if (bestIdx === -1) {
+      if (allowOver) return null;
+      return selectCanton(true);
+    }
+    let cell = popNeighbor(bestIdx);
+    while (cell === undefined) {
+      if (queues[bestIdx].length === 0) {
+        if (allowOver) return selectCanton(true);
+        return selectCanton(allowOver);
+      }
+      cell = popNeighbor(bestIdx);
+    }
+    return { idx: bestIdx, cell };
+  };
+
+  while (assigned < total) {
+    const selection = selectCanton(false) ?? selectCanton(true);
+    if (!selection) break;
+    const { idx, cell } = selection;
+    if (assignment.has(cell)) continue;
+    assignment.set(cell, idx);
+    sizes[idx] += 1;
+    assigned += 1;
+    const neighbors = adjacency.get(cell) || [];
+    for (const nb of neighbors) {
+      pushNeighbor(idx, nb);
+    }
+  }
+
+  return assignment;
+}
+
+function computeTileShares(
+  cells: CellId[],
+  biomes: Uint8Array,
+  neighbors: Int32Array,
+  offsets: Uint32Array,
+): { shares: Record<TileType, number>; coastal: boolean; perimeter: number } {
+  const counts = new Map<TileType, number>();
+  let coastal = false;
+  let perimeter = 0;
+  const owned = new Set(cells);
+  for (const cell of cells) {
+    const biome = biomes[cell];
+    const tile = BIOME_TILE_MAP[biome] ?? 'plains';
+    counts.set(tile, (counts.get(tile) ?? 0) + 1);
+    const start = offsets[cell];
+    const end = offsets[cell + 1];
+    for (let i = start; i < end; i++) {
+      const nb = neighbors[i];
+      if (nb < 0 || !owned.has(nb)) {
+        perimeter += 1;
+      }
+      if (nb >= 0) {
+        const nbBiome = biomes[nb];
+        if (nbBiome === 6 || nbBiome === 7) {
+          coastal = true;
+        }
+      }
+    }
+  }
+  const total = cells.length || 1;
+  const shares: Record<TileType, number> = {} as any;
+  for (const [tile, count] of counts.entries()) {
+    shares[tile] = count / total;
+  }
+  return { shares, coastal, perimeter };
+}
+
+function computeCentroid(cells: CellId[], centers: Float64Array): { x: number; y: number } {
+  if (cells.length === 0) return { x: 0, y: 0 };
+  let sumX = 0;
+  let sumY = 0;
+  for (const cell of cells) {
+    sumX += centers[2 * cell];
+    sumY += centers[2 * cell + 1];
+  }
+  const inv = 1 / cells.length;
+  return { x: sumX * inv, y: sumY * inv };
+}
+
+export function initializeCantons(
+  gameState: GameState,
+  presetMap: Record<PlayerId, NationPreset>,
+  neighbors: Int32Array,
+  offsets: Uint32Array,
+  centers: Float64Array,
+  biomes: Uint8Array,
+  _seed: string | number | null,
+): void {
+  for (const [playerId, cells] of Object.entries(gameState.playerCells)) {
+    if (!cells || cells.length === 0) {
+      gameState.nationCantons[playerId] = [];
+      continue;
+    }
+    const capital = cells[0];
+    gameState.playerCapitals[playerId] = capital;
+    const preset = presetMap[playerId] ?? 'Balanced Mixed Economy';
+    const totalCells = cells.length;
+    let cantonCount = determineCantonCount(totalCells, preset);
+    cantonCount = Math.min(cantonCount, totalCells);
+    if (cantonCount <= 0) cantonCount = 1;
+
+    const owned = new Set<CellId>(cells);
+    const adjacency = buildAdjacency(owned, neighbors, offsets);
+    const coastalCells: CellId[] = [];
+    for (const cell of cells) {
+      const start = offsets[cell];
+      const end = offsets[cell + 1];
+      for (let i = start; i < end; i++) {
+        const nb = neighbors[i];
+        if (nb >= 0) {
+          const biome = biomes[nb];
+          if (biome === 6 || biome === 7) {
+            coastalCells.push(cell);
+            break;
+          }
+        }
+      }
+    }
+
+    const seeds = selectSeeds(cells.slice(), centers, cantonCount, capital, coastalCells);
+    const targets = computeTargetSizes(totalCells, cantonCount);
+    const assignment = partitionWithBalancedGrowth(seeds, adjacency, targets);
+
+    const cantonCells: CellId[][] = Array.from({ length: cantonCount }, () => []);
+    for (const [cell, idx] of assignment.entries()) {
+      cantonCells[idx].push(cell);
+    }
+
+    const cantonIds: string[] = [];
+    gameState.nationCantons[playerId] = cantonIds;
+
+    for (let idx = 0; idx < cantonCount; idx++) {
+      const cellsForCanton = cantonCells[idx];
+      if (cellsForCanton.length === 0) continue;
+      const cantonId = idx === 0 ? String(capital) : `${capital}-${idx}`;
+      cantonIds.push(cantonId);
+      if (!gameState.economy.cantons[cantonId]) {
+        EconomyManager.addCanton(gameState.economy, cantonId);
+      }
+      gameState.cantonCells[cantonId] = cellsForCanton.slice().sort((a, b) => a - b);
+      for (const cell of cellsForCanton) {
+        gameState.cellCantons[cell] = cantonId;
+      }
+      const { shares, coastal, perimeter } = computeTileShares(cellsForCanton, biomes, neighbors, offsets);
+      const centroid = computeCentroid(cellsForCanton, centers);
+      const meta: CantonTerritoryMeta = {
+        owner: playerId,
+        capital: cellsForCanton.includes(capital),
+        coastal,
+        area: cellsForCanton.length,
+        centroid,
+        perimeter,
+        tileShares: shares,
+      };
+      gameState.cantonMeta[cantonId] = meta;
+      const canton = gameState.economy.cantons[cantonId];
+      canton.geography = shares;
+    }
+
+    // Ensure capital canton exists even if partition collapsed.
+    if (!gameState.cellCantons[capital]) {
+      const cantonId = String(capital);
+      if (!gameState.economy.cantons[cantonId]) {
+        EconomyManager.addCanton(gameState.economy, cantonId);
+      }
+      gameState.cellCantons[capital] = cantonId;
+      gameState.cantonCells[cantonId] = [capital];
+      gameState.nationCantons[playerId] = [cantonId];
+      gameState.cantonMeta[cantonId] = {
+        owner: playerId,
+        capital: true,
+        coastal: coastalCells.includes(capital),
+        area: 1,
+        centroid: { x: centers[2 * capital], y: centers[2 * capital + 1] },
+        perimeter: 0,
+        tileShares: { plains: 1 },
+      };
+    }
+  }
+}

--- a/server/src/game-state/index.ts
+++ b/server/src/game-state/index.ts
@@ -3,3 +3,4 @@ export * from './manager';
 export * from './service';
 export { GameStateManager } from './manager';
 export { GameService } from './service';
+export { auditGameIntegrity, authoritativeStore } from './authority';

--- a/server/src/game-state/manager.ts
+++ b/server/src/game-state/manager.ts
@@ -55,7 +55,12 @@ export class GameStateManager {
       // Initialize empty ownership maps
       cellOwnership: {},
       playerCells: Object.fromEntries(players.map(p => [p, []])),
-      
+      playerCapitals: Object.fromEntries(players.map(p => [p, undefined])),
+      cellCantons: {},
+      cantonCells: {},
+      nationCantons: Object.fromEntries(players.map(p => [p, []])),
+      cantonMeta: {},
+
       // Initialize empty entity tracking
       entities: {},
       cellEntities: {},
@@ -373,11 +378,12 @@ export class GameStateManager {
     for (const player of players) {
       const cells = this.getPlayerCells(gameState, player);
       if (cells.length === 0) continue;
-      const capital = cells[0];
-      const cantonId = String(capital);
+      const capital = gameState.playerCapitals[player] ?? cells[0];
+      const cantonId = gameState.cellCantons[capital] ?? String(capital);
 
-      // Ensure a canton exists for this capital cell
-      EconomyManager.addCanton(gameState.economy, cantonId);
+      if (!gameState.economy.cantons[cantonId]) {
+        EconomyManager.addCanton(gameState.economy, cantonId);
+      }
 
       const base: InfrastructureData = {
         owner: 'national',

--- a/server/src/game-state/service.ts
+++ b/server/src/game-state/service.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync, readdirSync } from 'fs';
 import { encode, decode } from '../serialization';
 import { GameStateManager } from './manager';
+import { authoritativeStore, type UpdateResult } from './authority';
 import type {
   Game,
   GameState,
@@ -17,25 +18,26 @@ import { InMediaResInitializer } from './inmediares';
 import { initializeCantons } from './cantons';
 import { SeededRandom } from '../utils/random';
 
-// In-memory game store (replace with database later)
-const games = new Map<string, Game>();
-
 export class GameService {
-  
+
   // === PERSISTENCE ===
-  
+
   private static async ensureMapsDir(): Promise<void> {
     if (!existsSync('maps')) {
       await mkdir('maps', { recursive: true });
     }
   }
 
-  static async saveGame(game: Game): Promise<void> {
+  private static async saveGame(gameId: string): Promise<void> {
     await this.ensureMapsDir();
-    
-    // JSON storage with TypedArray support
-    const filePath = `maps/${game.meta.gameId}.game.json`;
-    const jsonData = encode(game);
+
+    const canonical = authoritativeStore.getMutableGame(gameId);
+    if (!canonical) {
+      throw new Error(`Cannot save missing game ${gameId}`);
+    }
+
+    const filePath = `maps/${canonical.meta.gameId}.game.json`;
+    const jsonData = encode(canonical);
     await writeFile(filePath, jsonData, 'utf-8');
   }
 
@@ -75,7 +77,7 @@ export class GameService {
     try {
       const jsonData = await readFile(filePath, 'utf-8');
       const game = decode<Game>(jsonData);
-      
+      authoritativeStore.register(game);
       return game;
     } catch (error) {
       console.error(`Failed to load game for ${gameId}:`, error);
@@ -165,73 +167,99 @@ export class GameService {
     // Only the creator is in the lobby initially
     game.meta.players = ['player1'];
 
-    // Store in memory
-    games.set(gameId, game);
+    // Store as authoritative canonical state
+    authoritativeStore.register(game);
 
     // Persist to disk
-    await this.saveGame(game);
+    await this.saveGame(gameId);
     await this.saveGameMap(gameId, game.map);
 
     console.log(
       `Created game ${gameId} with join code ${joinCode} (${mapSize}, ${cellCount} cells, ${nationCount} nations)`
     );
 
-    return game;
+    const snapshot = authoritativeStore.getGame(gameId);
+    if (!snapshot) {
+      throw new Error('Failed to materialize authoritative game snapshot after creation');
+    }
+    return snapshot as Game;
   }
 
   static async getGame(gameId: string): Promise<Game | null> {
-    // Check in-memory first
-    if (games.has(gameId)) {
-      return games.get(gameId)!;
+    const snapshot = authoritativeStore.getGame(gameId);
+    if (snapshot) {
+      return snapshot as Game;
     }
 
-    // Try to load from disk
-    const game = await this.loadGame(gameId);
-    if (game) {
-      // Load the map separately
-      const gameMap = await this.loadGameMap(gameId);
-      if (gameMap) {
-        game.map = gameMap;
-      }
-      
-      // Cache in memory for future requests
-      games.set(gameId, game);
-      return game;
+    // Try to load from disk and register
+    const loaded = await this.loadGame(gameId);
+    if (!loaded) {
+      return null;
     }
 
-    return null;
+    const map = await this.loadGameMap(gameId);
+    if (map) {
+      loaded.map = map;
+    }
+
+    // loadGame registers canonical; fetch snapshot for return
+    const view = authoritativeStore.getGame(gameId);
+    return view ? (view as Game) : null;
   }
 
   static async getGameState(gameId: string): Promise<GameState | null> {
-    const game = await this.getGame(gameId);
-    return game ? game.state : null;
+    const state = authoritativeStore.getState(gameId);
+    if (state) {
+      return state as GameState;
+    }
+    await this.getGame(gameId);
+    const refreshed = authoritativeStore.getState(gameId);
+    return refreshed ? (refreshed as GameState) : null;
   }
 
   static async getGameMeta(gameId: string): Promise<GameMeta | null> {
-    const game = await this.getGame(gameId);
-    return game ? game.meta : null;
+    const meta = authoritativeStore.getMeta(gameId);
+    if (meta) {
+      return meta as GameMeta;
+    }
+    await this.getGame(gameId);
+    const refreshed = authoritativeStore.getMeta(gameId);
+    return refreshed ? (refreshed as GameMeta) : null;
   }
 
   static async getGameMap(gameId: string): Promise<GameMap | null> {
-    const game = await this.getGame(gameId);
-    return game ? game.map : null;
-  }
-
-  static async saveGameState(gameState: GameState, gameId: string): Promise<void> {
-    const game = games.get(gameId);
-    if (game) {
-      game.state = gameState;
-      await this.saveGame(game);
+    const map = authoritativeStore.getMap(gameId);
+    if (map) {
+      return map as GameMap;
     }
+    await this.getGame(gameId);
+    const refreshed = authoritativeStore.getMap(gameId);
+    return refreshed ? (refreshed as GameMap) : null;
   }
 
-  static async findGameByJoinCode(joinCode: string): Promise<Game | null> {
+  static async updateGame<T>(
+    gameId: string,
+    mutator: (game: Game) => T | Promise<T>,
+  ): Promise<UpdateResult<T>> {
+    const result = await authoritativeStore.update(gameId, mutator);
+    await this.saveGame(gameId);
+    return result;
+  }
+
+  static async updateGameState<T>(
+    gameId: string,
+    mutator: (state: GameState, game: Game) => T | Promise<T>,
+  ): Promise<UpdateResult<T>> {
+    return this.updateGame(gameId, game => mutator(game.state, game));
+  }
+
+  static async findGameByJoinCode(joinCode: string): Promise<string | null> {
     const upperJoinCode = joinCode.toUpperCase();
 
-    // Search in-memory games first
-    for (const game of games.values()) {
-      if (game.meta.joinCode === upperJoinCode) {
-        return game;
+    // Search authoritative in-memory games first
+    for (const snapshot of authoritativeStore.listSnapshots()) {
+      if (snapshot.meta.joinCode === upperJoinCode) {
+        return snapshot.meta.gameId;
       }
     }
 
@@ -240,15 +268,13 @@ export class GameService {
       if (existsSync('maps')) {
         const fileExtension = '.game.json';
         const files = readdirSync('maps').filter(f => f.endsWith(fileExtension));
-        
+
         for (const file of files) {
           const gameId = file.replace(fileExtension, '');
           const game = await this.loadGame(gameId);
-          
+
           if (game && game.meta.joinCode === upperJoinCode) {
-            // Cache in memory for future requests
-            games.set(gameId, game);
-            return game;
+            return gameId;
           }
         }
       }
@@ -260,110 +286,112 @@ export class GameService {
   }
 
   static async joinGame(joinCode: string): Promise<{ game: Game; playerName: string } | null> {
-    const game = await this.findGameByJoinCode(joinCode);
-    
-    if (!game) {
+    const gameId = await this.findGameByJoinCode(joinCode);
+
+    if (!gameId) {
       return null;
     }
 
-    if (!GameStateManager.canPlayerJoin(game.state)) {
-      throw new Error(`Game is no longer accepting players (status: ${game.state.status})`);
-    }
-
-    if (game.meta.players.length >= game.meta.nationCount) {
-      throw new Error('Game is full');
-    }
-
-    // Generate new player name
-    const playerNumber = game.meta.players.length + 1;
-    const newPlayerName = `player${playerNumber}`;
-
-    // Update meta with new player
-    game.meta.players.push(newPlayerName);
-
-    // Add player to game state if not pre-generated
-    if (!game.state.playerCells[newPlayerName]) {
-      const success = GameStateManager.addPlayer(game.state, newPlayerName);
-      if (!success) {
-        throw new Error('Failed to add player to game');
+    const { game, result } = await this.updateGame(gameId, canonical => {
+      if (!GameStateManager.canPlayerJoin(canonical.state)) {
+        throw new Error(`Game is no longer accepting players (status: ${canonical.state.status})`);
       }
-    }
 
-    // Persist updated state
-    await this.saveGame(game);
+      if (canonical.meta.players.length >= canonical.meta.nationCount) {
+        throw new Error('Game is full');
+      }
+
+      const playerNumber = canonical.meta.players.length + 1;
+      const newPlayerName = `player${playerNumber}`;
+
+      canonical.meta.players.push(newPlayerName);
+
+      if (!canonical.state.playerCells[newPlayerName]) {
+        const success = GameStateManager.addPlayer(canonical.state, newPlayerName);
+        if (!success) {
+          throw new Error('Failed to add player to game');
+        }
+      }
+
+      return newPlayerName;
+    });
+
+    const newPlayerName = result;
 
     console.log(`Player ${newPlayerName} joined game ${game.meta.gameId} (${game.meta.players.length} total players)`);
 
-    return { game, playerName: newPlayerName };
+    return { game: game as Game, playerName: newPlayerName };
   }
 
   static async startGame(gameId: string): Promise<Game | null> {
-    const game = await this.getGame(gameId);
-    
-    if (!game) {
+    const snapshot = await this.getGame(gameId);
+    if (!snapshot) {
       return null;
     }
 
-    if (game.state.status !== "waiting") {
-      throw new Error(`Game cannot be started (current status: ${game.state.status})`);
-    }
+    const { game } = await this.updateGame(gameId, canonical => {
+      if (canonical.state.status !== 'waiting') {
+        throw new Error(`Game cannot be started (current status: ${canonical.state.status})`);
+      }
 
-    if (game.meta.players.length < game.meta.nationCount) {
-      throw new Error(`Not enough players to start game (${game.meta.players.length}/${game.meta.nationCount} joined)`);
-    }
+      if (canonical.meta.players.length < canonical.meta.nationCount) {
+        throw new Error(
+          `Not enough players to start game (${canonical.meta.players.length}/${canonical.meta.nationCount} joined)`,
+        );
+      }
 
-    // Update game state to started
-    GameStateManager.startGame(game.state, game.meta.players);
-
-    // Persist updated state
-    await this.saveGame(game);
+      GameStateManager.startGame(canonical.state, canonical.meta.players);
+      return null;
+    });
 
     console.log(`Game ${gameId} started with ${game.meta.players.length} players`);
 
-    return game;
+    return game as Game;
   }
 
   static async leaveGame(gameId: string, playerId: PlayerId): Promise<Game | null> {
-    const game = await this.getGame(gameId);
-    if (!game) return null;
+    const snapshot = await this.getGame(gameId);
+    if (!snapshot) return null;
 
-    const idx = game.meta.players.indexOf(playerId);
-    if (idx === -1) throw new Error('Player not in game');
+    const { game } = await this.updateGame(gameId, canonical => {
+      const idx = canonical.meta.players.indexOf(playerId);
+      if (idx === -1) throw new Error('Player not in game');
 
-    // Remove from meta players
-    game.meta.players.splice(idx, 1);
+      canonical.meta.players.splice(idx, 1);
 
-    // Clean up game state collections
-    delete game.state.playerCells[playerId];
-    delete game.state.playerEntities[playerId];
+      delete canonical.state.playerCells[playerId];
+      delete canonical.state.playerEntities[playerId];
 
-    // Remove ownership and entities
-    for (const [cell, owner] of Object.entries(game.state.cellOwnership)) {
-      if (owner === playerId) {
-        delete game.state.cellOwnership[cell as any];
-        delete game.state.cellEntities[cell as any];
+      for (const [cell, owner] of Object.entries(canonical.state.cellOwnership)) {
+        if (owner === playerId) {
+          delete canonical.state.cellOwnership[cell as any];
+          delete canonical.state.cellEntities[cell as any];
+        }
       }
-    }
-    for (const [id, ent] of Object.entries(game.state.entities)) {
-      if (ent.owner === playerId) {
-        delete game.state.entities[id as any];
+      for (const [id, ent] of Object.entries(canonical.state.entities)) {
+        if (ent.owner === playerId) {
+          delete canonical.state.entities[id as any];
+        }
       }
-    }
 
-    if (game.state.currentPlayer === playerId) {
-      game.state.currentPlayer = game.meta.players[0] ?? null;
-    }
+      if (canonical.state.currentPlayer === playerId) {
+        canonical.state.currentPlayer = canonical.meta.players[0] ?? null;
+      }
 
-    await this.saveGame(game);
-    return game;
+      return null;
+    });
+
+    return game as Game;
   }
 
   static async endGame(gameId: string): Promise<Game | null> {
-    const game = await this.getGame(gameId);
-    if (!game) return null;
-    GameStateManager.finishGame(game.state);
-    await this.saveGame(game);
-    return game;
+    const snapshot = await this.getGame(gameId);
+    if (!snapshot) return null;
+    const { game } = await this.updateGame(gameId, canonical => {
+      GameStateManager.finishGame(canonical.state);
+      return null;
+    });
+    return game as Game;
   }
 
   // === TERRAIN DATA (LEGACY METHODS - DEPRECATED) ===
@@ -390,10 +418,10 @@ export class GameService {
   }
 
   static getAllGames(): Game[] {
-    return Array.from(games.values());
+    return authoritativeStore.listSnapshots().map(snapshot => snapshot.game as Game);
   }
 
   static getGameCount(): number {
-    return games.size;
+    return authoritativeStore.size;
   }
 }

--- a/server/src/game-state/service.ts
+++ b/server/src/game-state/service.ts
@@ -14,6 +14,7 @@ import type {
   NationMeta,
 } from '../types';
 import { InMediaResInitializer } from './inmediares';
+import { initializeCantons } from './cantons';
 import { SeededRandom } from '../utils/random';
 
 // In-memory game store (replace with database later)
@@ -126,6 +127,20 @@ export class GameService {
       biomes,
       7,
       () => territoryRandom.next(),
+    );
+
+    const presetMap = Object.fromEntries(
+      players.map((playerId, index) => [playerId, nationInputs[index].preset]),
+    );
+
+    initializeCantons(
+      game.state,
+      presetMap,
+      meshData.cellNeighbors,
+      meshData.cellOffsets,
+      meshData.cellTriangleCenters,
+      biomes,
+      normalizedSeed,
     );
 
     GameStateManager.initializeNationInfrastructure(

--- a/server/src/routes/lifecycle.test.ts
+++ b/server/src/routes/lifecycle.test.ts
@@ -57,8 +57,10 @@ test('submitted planner payload persists and executes next turn', async () => {
   const state = await GameService.getGameState(gameId);
   expect(state).not.toBeNull();
   if (!state) return;
-  state.economy.resources.gold = 1000;
-  await GameService.saveGameState(state, gameId);
+  await GameService.updateGameState(gameId, nextState => {
+    nextState.economy.resources.gold = 1000;
+    return null;
+  });
 
   const plan: TurnPlan = {
     budgets: { military: 30, welfare: 0, sectorOM: {} },
@@ -82,7 +84,7 @@ test('submitted planner payload persists and executes next turn', async () => {
   expect(updated?.nextPlan?.policies?.welfare?.education).toBe(1);
 
   // Execute turns directly with manager to check one-turn lag
-  const execState = updated!;
+  const execState = structuredClone(updated!);
   const goldBefore = execState.economy.resources.gold;
   TurnManager.advanceTurn(execState); // move plan into currentPlan
   const goldAfterFirst = execState.economy.resources.gold;

--- a/server/src/routes/lifecycle.test.ts
+++ b/server/src/routes/lifecycle.test.ts
@@ -57,7 +57,7 @@ test('submitted planner payload persists and executes next turn', async () => {
   const state = await GameService.getGameState(gameId);
   expect(state).not.toBeNull();
   if (!state) return;
-  state.economy.resources.gold = 100;
+  state.economy.resources.gold = 1000;
   await GameService.saveGameState(state, gameId);
 
   const plan: TurnPlan = {

--- a/server/src/routes/submitPlan.ts
+++ b/server/src/routes/submitPlan.ts
@@ -84,9 +84,11 @@ export async function submitPlan(gameId: string, req: Request) {
         headers: { "Content-Type": "application/json", ...CORS_HEADERS },
       });
     }
-    TurnManager.submitPlan(gameState, plan);
-    gameState.planSubmittedBy = playerId;
-    await GameService.saveGameState(gameState, gameId);
+    await GameService.updateGameState(gameId, state => {
+      TurnManager.submitPlan(state, plan);
+      state.planSubmittedBy = playerId;
+      return null;
+    });
     broadcastPlanSubmitted(gameId, playerId);
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -382,11 +382,21 @@ export interface CantonEconomy {
    */
   nextUrbanizationLevel: number;
   /** Geography mix for the canton; shares should sum to 1.0. */
-  geography: Record<TileType, number>;
+  geography: Partial<Record<TileType, number>>;
   /** Cached suitability percent by sector for ordering labor priority. */
   suitability: Partial<Record<SectorType, number>>;
   /** Cached suitability multiplier by sector applied after all other gates. */
   suitabilityMultipliers: Partial<Record<SectorType, number>>;
+}
+
+export interface CantonTerritoryMeta {
+  owner: PlayerId;
+  capital: boolean;
+  coastal: boolean;
+  area: number;
+  centroid: { x: number; y: number };
+  perimeter: number;
+  tileShares: Partial<Record<TileType, number>>;
 }
 
 export type InfrastructureType = 'airport' | 'port' | 'rail';
@@ -590,6 +600,31 @@ export interface GameState {
    * Key: PlayerId, Value: Array of CellIds owned by that player
    */
   playerCells: { [playerId: PlayerId]: CellId[] };
+
+  /**
+   * Records the designated capital cell for each player.
+   */
+  playerCapitals: { [playerId: PlayerId]: CellId | undefined };
+
+  /**
+   * Maps each cell to its assigned canton identifier.
+   */
+  cellCantons: { [cellId: CellId]: string | undefined };
+
+  /**
+   * Lists the cells that compose each canton region.
+   */
+  cantonCells: { [cantonId: string]: CellId[] };
+
+  /**
+   * Canton membership for each nation in initialization order.
+   */
+  nationCantons: { [playerId: PlayerId]: string[] };
+
+  /**
+   * Precomputed territorial metadata for each canton.
+   */
+  cantonMeta: Record<string, CantonTerritoryMeta>;
 
   /**
    * Maps entity IDs to their full entity data.

--- a/server/src/websocket/turn-events.test.ts
+++ b/server/src/websocket/turn-events.test.ts
@@ -40,29 +40,31 @@ test('websocket turn flow emits ordered events and survives reconnect', async ()
 
   const state = await GameService.getGameState(gameId);
   if (!state) throw new Error('state missing');
-  state.economy.infrastructure.ports['A'] = { owner:'national', status:'inactive', national:false, hp:100, toggle:{ target:'active', turns:1 } } as any;
-  state.economy.cantons['C1'] = {
-    sectors: { agriculture: { capacity: 5, funded: 0, idle: 0, utilization: 0 } },
-    labor: { general: 0, skilled: 0, specialist: 0 },
-    laborDemand: {},
-    laborAssigned: {},
-    lai: 0,
-    happiness: 0,
-    consumption: { foodRequired: 0, foodProvided: 0, luxuryRequired: 0, luxuryProvided: 0 },
-    shortages: { food: false, luxury: false },
-    urbanizationLevel: 1,
-    development: 0,
-    nextUrbanizationLevel: 2,
-    geography: {},
-    suitability: { agriculture: 0 },
-    suitabilityMultipliers: {},
-  } as any;
-  state.economy.finance.creditLimit = 10;
-  state.economy.finance.debt = 0;
-  state.economy.finance.defaulted = false;
-  state.economy.resources.gold = 20;
-  state.currentPlan = { budgets:{ military:50, welfare:0, sectorOM:{ agriculture:5 } }, policies:{}, slotPriorities:{}, tradeOrders:{}, projects:{} } as any;
-  await GameService.saveGameState(state, gameId);
+  await GameService.updateGameState(gameId, gameState => {
+    gameState.economy.infrastructure.ports['A'] = { owner:'national', status:'inactive', national:false, hp:100, toggle:{ target:'active', turns:1 } } as any;
+    gameState.economy.cantons['C1'] = {
+      sectors: { agriculture: { capacity: 5, funded: 0, idle: 0, utilization: 0 } },
+      labor: { general: 0, skilled: 0, specialist: 0 },
+      laborDemand: {},
+      laborAssigned: {},
+      lai: 0,
+      happiness: 0,
+      consumption: { foodRequired: 0, foodProvided: 0, luxuryRequired: 0, luxuryProvided: 0 },
+      shortages: { food: false, luxury: false },
+      urbanizationLevel: 1,
+      development: 0,
+      nextUrbanizationLevel: 2,
+      geography: {},
+      suitability: { agriculture: 0 },
+      suitabilityMultipliers: {},
+    } as any;
+    gameState.economy.finance.creditLimit = 10;
+    gameState.economy.finance.debt = 0;
+    gameState.economy.finance.defaulted = false;
+    gameState.economy.resources.gold = 20;
+    gameState.currentPlan = { budgets:{ military:50, welfare:0, sectorOM:{ agriculture:5 } }, policies:{}, slotPriorities:{}, tradeOrders:{}, projects:{} } as any;
+    return null;
+  });
 
   const advReq = new Request('http://localhost', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ playerId:'player1' }) });
   const advRes = await advanceTurn(gameId, advReq);
@@ -71,8 +73,10 @@ test('websocket turn flow emits ordered events and survives reconnect', async ()
 
   const post = await GameService.getGameState(gameId);
   if (post) {
-    post.economy.resources.gold = 0;
-    await GameService.saveGameState(post, gameId);
+    await GameService.updateGameState(gameId, state => {
+      state.economy.resources.gold = 0;
+      return null;
+    });
   }
 
   ws1.close();


### PR DESCRIPTION
## Summary
- add a canton partitioner that builds contiguous regions per nation, records metadata, and respects archetype canton bands
- extend the game state and initialization flows to seed per-canton economies and infrastructure using the new assignments
- cover the partitioning workflow with tests that validate coverage, contiguity, and coastal guarantees

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d9a5f5f298832787de23284aececbc