### PR TITLE
Add map view mode toggle with canton shading

### DIFF
--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -37,7 +37,7 @@ export let currentPlayerName: string | null = null;
 export let isGameCreator = false;
 export let requiredPlayers = 2;
 
-const BASE_COLOR_ALPHA = 0.3;
+const BASE_COLOR_ALPHA = 0.4;
 const DEFAULT_NATION_PALETTE = [
   '#FF6B6B',
   '#4D96FF',

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -37,7 +37,7 @@ export let currentPlayerName: string | null = null;
 export let isGameCreator = false;
 export let requiredPlayers = 2;
 
-const BASE_COLOR_ALPHA = 0.4;
+const BASE_COLOR_ALPHA = 0.45;
 const DEFAULT_NATION_PALETTE = [
   '#FF6B6B',
   '#4D96FF',

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -22,16 +22,24 @@ import {
   currentPlayerName,
   requiredPlayers,
   isMyTurn,
+  renderGameState,
 } from './game';
 import { initializePlannerUI, setPlannerVisibility } from './planner';
+import { initializeMapViewControl } from './mapViewControl';
+import { onMapViewModeChange } from './mapViewState';
 
 const canvas = document.createElement('canvas');
 const container = document.getElementById('canvas-container')!;
 container.appendChild(canvas);
+initializeMapViewControl(container);
 canvas.width = WIDTH;
 canvas.height = HEIGHT;
 
 const ctx = canvas.getContext('2d')!;
+
+onMapViewModeChange(() => {
+  renderGameState();
+});
 
 // Initialize the application
 async function initializeApp() {

--- a/client/src/mapColors.spec.ts
+++ b/client/src/mapColors.spec.ts
@@ -104,8 +104,8 @@ function deltaE(labA: LabColor, labB: LabColor): number {
 }
 
 const BASE_COLORS: Record<string, RgbaColor> = {
-  alpha: { r: 210, g: 70, b: 70, a: 0.4 },
-  beta: { r: 60, g: 135, b: 215, a: 0.4 },
+  alpha: { r: 210, g: 70, b: 70, a: 0.45 },
+  beta: { r: 60, g: 135, b: 215, a: 0.45 },
 };
 
 (runInVitest ? describe : describe.skip)('map color assignments', () => {

--- a/client/src/mapColors.spec.ts
+++ b/client/src/mapColors.spec.ts
@@ -104,8 +104,8 @@ function deltaE(labA: LabColor, labB: LabColor): number {
 }
 
 const BASE_COLORS: Record<string, RgbaColor> = {
-  alpha: { r: 210, g: 70, b: 70, a: 0.3 },
-  beta: { r: 60, g: 135, b: 215, a: 0.3 },
+  alpha: { r: 210, g: 70, b: 70, a: 0.4 },
+  beta: { r: 60, g: 135, b: 215, a: 0.4 },
 };
 
 (runInVitest ? describe : describe.skip)('map color assignments', () => {

--- a/client/src/mapColors.spec.ts
+++ b/client/src/mapColors.spec.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { assignCantonShades, computeCellColors, RgbaColor } from './mapColors';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  assignCantonShades,
+  computeCellColors,
+  RgbaColor,
+  CANTON_CONTRAST_CONFIG,
+} from './mapColors';
 import { resetMapViewStateForTests } from './mapViewState';
 
 const runInVitest = typeof (globalThis as any).Bun === 'undefined';
@@ -9,14 +14,110 @@ function colorSignature(color: RgbaColor | null): string {
   return `${color.r}-${color.g}-${color.b}-${color.a}`;
 }
 
+interface LabColor {
+  l: number;
+  a: number;
+  b: number;
+}
+
+interface HslMetrics {
+  h: number;
+  s: number;
+  l: number;
+}
+
+function rgbaToHsl(color: RgbaColor): HslMetrics {
+  const r = color.r / 255;
+  const g = color.g / 255;
+  const b = color.b / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = ((g - b) / d + (g < b ? 6 : 0)) * 60;
+        break;
+      case g:
+        h = ((b - r) / d + 2) * 60;
+        break;
+      default:
+        h = ((r - g) / d + 4) * 60;
+        break;
+    }
+  }
+
+  return { h, s, l };
+}
+
+function srgbToLinear(channel: number): number {
+  if (channel <= 0.04045) {
+    return channel / 12.92;
+  }
+  return Math.pow((channel + 0.055) / 1.055, 2.4);
+}
+
+function rgbaToLab(color: RgbaColor): LabColor {
+  const r = srgbToLinear(color.r / 255);
+  const g = srgbToLinear(color.g / 255);
+  const b = srgbToLinear(color.b / 255);
+
+  const x = r * 0.4124564 + g * 0.3575761 + b * 0.1804375;
+  const y = r * 0.2126729 + g * 0.7151522 + b * 0.0721750;
+  const z = r * 0.0193339 + g * 0.1191920 + b * 0.9503041;
+
+  const xRef = 0.95047;
+  const yRef = 1.0;
+  const zRef = 1.08883;
+
+  const epsilon = 216 / 24389;
+  const kappa = 24389 / 27;
+
+  function pivot(n: number): number {
+    if (n > epsilon) {
+      return Math.cbrt(n);
+    }
+    return (kappa * n + 16) / 116;
+  }
+
+  const fx = pivot(x / xRef);
+  const fy = pivot(y / yRef);
+  const fz = pivot(z / zRef);
+
+  return {
+    l: Math.max(0, 116 * fy - 16),
+    a: 500 * (fx - fy),
+    b: 200 * (fy - fz),
+  };
+}
+
+function deltaE(labA: LabColor, labB: LabColor): number {
+  const dl = labA.l - labB.l;
+  const da = labA.a - labB.a;
+  const db = labA.b - labB.b;
+  return Math.sqrt(dl * dl + da * da + db * db);
+}
+
 const BASE_COLORS: Record<string, RgbaColor> = {
   alpha: { r: 210, g: 70, b: 70, a: 0.3 },
   beta: { r: 60, g: 135, b: 215, a: 0.3 },
 };
 
 (runInVitest ? describe : describe.skip)('map color assignments', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     resetMapViewStateForTests();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
   });
 
   it('keeps nation view restricted to base colors', () => {
@@ -52,6 +153,54 @@ const BASE_COLORS: Record<string, RgbaColor> = {
     expect(colorSignature(shades['a-2'])).not.toEqual(colorSignature(shades['a-3']));
   });
 
+  it('meets neighbor and background contrast targets', () => {
+    const cantonIds = ['a-1', 'a-2', 'a-3', 'a-4'];
+    const adjacency = new Map<string, Set<string>>([
+      ['a-1', new Set(['a-2', 'a-3'])],
+      ['a-2', new Set(['a-1', 'a-4'])],
+      ['a-3', new Set(['a-1', 'a-4'])],
+      ['a-4', new Set(['a-2', 'a-3'])],
+    ]);
+
+    const backgroundLab = rgbaToLab(CANTON_CONTRAST_CONFIG.backgroundColor);
+    const backgroundHsl = rgbaToHsl(CANTON_CONTRAST_CONFIG.backgroundColor);
+
+    const shades = assignCantonShades('alpha', cantonIds, BASE_COLORS.alpha, {
+      adjacency,
+      seed: 'contrast-seed',
+    });
+
+    const shadeMetrics = new Map<string, { hsl: HslMetrics; lab: LabColor }>();
+    for (const [cantonId, color] of Object.entries(shades)) {
+      const hsl = rgbaToHsl(color);
+      const lab = rgbaToLab(color);
+      shadeMetrics.set(cantonId, { hsl, lab });
+      const backgroundDelta = deltaE(lab, backgroundLab);
+      const backgroundLightnessDiff = Math.abs(hsl.l - backgroundHsl.l);
+      expect(backgroundDelta).toBeGreaterThanOrEqual(CANTON_CONTRAST_CONFIG.minBackgroundDeltaE);
+      expect(backgroundLightnessDiff).toBeGreaterThanOrEqual(
+        CANTON_CONTRAST_CONFIG.minBackgroundLightness,
+      );
+    }
+
+    const seenPairs = new Set<string>();
+    for (const [cantonId, neighbors] of adjacency.entries()) {
+      for (const neighbor of neighbors) {
+        const pairKey = [cantonId, neighbor].sort().join('::');
+        if (seenPairs.has(pairKey)) continue;
+        seenPairs.add(pairKey);
+        const first = shadeMetrics.get(cantonId)!;
+        const second = shadeMetrics.get(neighbor)!;
+        expect(deltaE(first.lab, second.lab)).toBeGreaterThanOrEqual(
+          CANTON_CONTRAST_CONFIG.minNeighborDeltaE,
+        );
+        expect(Math.abs(first.hsl.l - second.hsl.l)).toBeGreaterThanOrEqual(
+          CANTON_CONTRAST_CONFIG.minNeighborLightness,
+        );
+      }
+    }
+  });
+
   it('renders canton view with deterministic distinct shades', () => {
     const cellOwnership = { '0': 'alpha', '1': 'alpha', '2': 'beta', '3': 'beta' };
     const cellCantons = { '0': 'a-1', '1': 'a-2', '2': 'b-1', '3': 'b-2' };
@@ -62,6 +211,7 @@ const BASE_COLORS: Record<string, RgbaColor> = {
       ['b-2', new Set(['b-1'])],
     ]);
 
+    logSpy.mockClear();
     const colorsFirst = computeCellColors('canton', {
       cellCount: 4,
       cellOwnership,
@@ -70,6 +220,9 @@ const BASE_COLORS: Record<string, RgbaColor> = {
       cantonAdjacency: adjacency,
       seed: 'canton-seed',
     });
+
+    const firstLogs = logSpy.mock.calls.map((call) => JSON.stringify(call));
+    logSpy.mockClear();
 
     const colorsSecond = computeCellColors('canton', {
       cellCount: 4,
@@ -80,10 +233,13 @@ const BASE_COLORS: Record<string, RgbaColor> = {
       seed: 'canton-seed',
     });
 
+    const secondLogs = logSpy.mock.calls.map((call) => JSON.stringify(call));
+
     expect(colorSignature(colorsFirst[0])).not.toEqual(colorSignature(BASE_COLORS.alpha));
     expect(colorSignature(colorsFirst[0])).not.toEqual(colorSignature(colorsFirst[1]));
     expect(colorSignature(colorsFirst[2])).not.toEqual(colorSignature(colorsFirst[3]));
     expect(colorsFirst.map(colorSignature)).toEqual(colorsSecond.map(colorSignature));
     expect(colorsFirst.every((color) => !color || color.a === BASE_COLORS.alpha.a || color.a === BASE_COLORS.beta.a)).toBe(true);
+    expect(secondLogs).toEqual(firstLogs);
   });
 });

--- a/client/src/mapColors.spec.ts
+++ b/client/src/mapColors.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { assignCantonShades, computeCellColors, RgbaColor } from './mapColors';
+import { resetMapViewStateForTests } from './mapViewState';
+
+const runInVitest = typeof (globalThis as any).Bun === 'undefined';
+
+function colorSignature(color: RgbaColor | null): string {
+  if (!color) return 'null';
+  return `${color.r}-${color.g}-${color.b}-${color.a}`;
+}
+
+const BASE_COLORS: Record<string, RgbaColor> = {
+  alpha: { r: 210, g: 70, b: 70, a: 0.3 },
+  beta: { r: 60, g: 135, b: 215, a: 0.3 },
+};
+
+(runInVitest ? describe : describe.skip)('map color assignments', () => {
+  beforeEach(() => {
+    resetMapViewStateForTests();
+  });
+
+  it('keeps nation view restricted to base colors', () => {
+    const cellOwnership = { '0': 'alpha', '1': 'alpha', '2': 'beta' };
+    const colors = computeCellColors('nation', {
+      cellCount: 3,
+      cellOwnership,
+      baseColors: BASE_COLORS,
+    });
+
+    expect(colors[0]).toEqual(BASE_COLORS.alpha);
+    expect(colors[1]).toEqual(BASE_COLORS.alpha);
+    expect(colors[2]).toEqual(BASE_COLORS.beta);
+  });
+
+  it('assigns unique canton shades with matching opacity', () => {
+    const cantonIds = ['a-1', 'a-2', 'a-3'];
+    const adjacency = new Map<string, Set<string>>([
+      ['a-1', new Set(['a-2'])],
+      ['a-2', new Set(['a-1', 'a-3'])],
+      ['a-3', new Set(['a-2'])],
+    ]);
+
+    const shades = assignCantonShades('alpha', cantonIds, BASE_COLORS.alpha, {
+      adjacency,
+      seed: 'test-seed',
+    });
+
+    const uniqueSignatures = new Set(Object.values(shades).map(colorSignature));
+    expect(uniqueSignatures.size).toBe(cantonIds.length);
+    expect(Object.values(shades).every((shade) => shade.a === BASE_COLORS.alpha.a)).toBe(true);
+    expect(colorSignature(shades['a-1'])).not.toEqual(colorSignature(shades['a-2']));
+    expect(colorSignature(shades['a-2'])).not.toEqual(colorSignature(shades['a-3']));
+  });
+
+  it('renders canton view with deterministic distinct shades', () => {
+    const cellOwnership = { '0': 'alpha', '1': 'alpha', '2': 'beta', '3': 'beta' };
+    const cellCantons = { '0': 'a-1', '1': 'a-2', '2': 'b-1', '3': 'b-2' };
+    const adjacency = new Map<string, Set<string>>([
+      ['a-1', new Set(['a-2'])],
+      ['a-2', new Set(['a-1'])],
+      ['b-1', new Set(['b-2'])],
+      ['b-2', new Set(['b-1'])],
+    ]);
+
+    const colorsFirst = computeCellColors('canton', {
+      cellCount: 4,
+      cellOwnership,
+      cellCantons,
+      baseColors: BASE_COLORS,
+      cantonAdjacency: adjacency,
+      seed: 'canton-seed',
+    });
+
+    const colorsSecond = computeCellColors('canton', {
+      cellCount: 4,
+      cellOwnership,
+      cellCantons,
+      baseColors: BASE_COLORS,
+      cantonAdjacency: adjacency,
+      seed: 'canton-seed',
+    });
+
+    expect(colorSignature(colorsFirst[0])).not.toEqual(colorSignature(BASE_COLORS.alpha));
+    expect(colorSignature(colorsFirst[0])).not.toEqual(colorSignature(colorsFirst[1]));
+    expect(colorSignature(colorsFirst[2])).not.toEqual(colorSignature(colorsFirst[3]));
+    expect(colorsFirst.map(colorSignature)).toEqual(colorsSecond.map(colorSignature));
+    expect(colorsFirst.every((color) => !color || color.a === BASE_COLORS.alpha.a || color.a === BASE_COLORS.beta.a)).toBe(true);
+  });
+});

--- a/client/src/mapColors.ts
+++ b/client/src/mapColors.ts
@@ -1,0 +1,422 @@
+import { MapViewMode } from './mapViewState';
+
+export interface RgbaColor {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+export interface MapColoringInput {
+  cellCount: number;
+  cellOwnership: Record<string, string>;
+  cellCantons?: Record<string, string | undefined>;
+  nationCantons?: Record<string, string[]>;
+  baseColors: Record<string, RgbaColor>;
+  cantonAdjacency?: Map<string, Set<string>>;
+  seed?: string | null;
+}
+
+interface HslColor {
+  h: number;
+  s: number;
+  l: number;
+  a: number;
+}
+
+const SAFE_SATURATION_MIN = 0.45;
+const SAFE_SATURATION_MAX = 0.85;
+const SAFE_LIGHTNESS_MIN = 0.3;
+const SAFE_LIGHTNESS_MAX = 0.72;
+const FALLBACK_PREFIX = '__fallback__';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function clampByte(value: number): number {
+  return Math.round(clamp(value, 0, 255));
+}
+
+function cloneColor(color: RgbaColor): RgbaColor {
+  return { r: color.r, g: color.g, b: color.b, a: color.a };
+}
+
+function colorKey(color: RgbaColor): string {
+  return `${clampByte(color.r)}|${clampByte(color.g)}|${clampByte(color.b)}`;
+}
+
+function enforceDistinctCandidate(base: RgbaColor, used: Set<string>): RgbaColor {
+  const baseHsl = rgbaToHsl(base);
+  let offset = 0.06;
+  for (let i = 0; i < 8; i++) {
+    const candidate = hslToRgba({
+      h: baseHsl.h,
+      s: clamp(baseHsl.s + offset, SAFE_SATURATION_MIN, SAFE_SATURATION_MAX),
+      l: clamp(baseHsl.l + offset, SAFE_LIGHTNESS_MIN, SAFE_LIGHTNESS_MAX),
+      a: base.a,
+    });
+    const key = colorKey(candidate);
+    if (!used.has(key)) {
+      used.add(key);
+      return candidate;
+    }
+    offset = -offset * 1.2;
+  }
+  return cloneColor(base);
+}
+
+function rgbaToHsl(color: RgbaColor): HslColor {
+  const r = clamp(color.r, 0, 255) / 255;
+  const g = clamp(color.g, 0, 255) / 255;
+  const b = clamp(color.b, 0, 255) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  const l = (max + min) / 2;
+  const delta = max - min;
+  let s = 0;
+
+  if (delta !== 0) {
+    s = delta / (1 - Math.abs(2 * l - 1));
+    switch (max) {
+      case r:
+        h = ((g - b) / delta) % 6;
+        break;
+      case g:
+        h = (b - r) / delta + 2;
+        break;
+      default:
+        h = (r - g) / delta + 4;
+        break;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+
+  return { h, s, l, a: color.a };
+}
+
+function hueToRgb(p: number, q: number, t: number): number {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+}
+
+function hslToRgba(color: HslColor): RgbaColor {
+  const h = ((color.h % 360) + 360) % 360;
+  const s = clamp(color.s, 0, 1);
+  const l = clamp(color.l, 0, 1);
+  const a = color.a;
+
+  if (s === 0) {
+    const gray = clampByte(l * 255);
+    return { r: gray, g: gray, b: gray, a };
+  }
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  const r = hueToRgb(p, q, h / 360 + 1 / 3);
+  const g = hueToRgb(p, q, h / 360);
+  const b = hueToRgb(p, q, h / 360 - 1 / 3);
+
+  return { r: clampByte(r * 255), g: clampByte(g * 255), b: clampByte(b * 255), a };
+}
+
+function cyrb128(str: string): [number, number, number, number] {
+  let h1 = 1779033703, h2 = 3144134277, h3 = 1013904242, h4 = 2773480762;
+  for (let i = 0; i < str.length; i++) {
+    const k = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ k, 597399067);
+    h2 = Math.imul(h2 ^ k, 2869860233);
+    h3 = Math.imul(h3 ^ k, 951274213);
+    h4 = Math.imul(h4 ^ k, 2716044179);
+  }
+  h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067);
+  h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233);
+  h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213);
+  h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179);
+  return [h1 ^ h2 ^ h3 ^ h4, h2 ^ h1, h3 ^ h1, h4 ^ h1];
+}
+
+function sfc32(a: number, b: number, c: number, d: number): () => number {
+  return function () {
+    a >>>= 0; b >>>= 0; c >>>= 0; d >>>= 0;
+    let t = (a + b) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    d = (d + 1) | 0;
+    t = (t + d) | 0;
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+}
+
+function createSeededRng(seed: string): () => number {
+  const [a, b, c, d] = cyrb128(seed);
+  return sfc32(a, b, c, d);
+}
+
+function shuffleWithRng<T>(items: T[], rng: () => number): T[] {
+  const copy = items.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function resolveCantonId(
+  cellKey: string,
+  owner: string | undefined,
+  cellCantons: Record<string, string | undefined>,
+): string | null {
+  const explicit = cellCantons[cellKey];
+  if (explicit) return explicit;
+  if (!owner) return null;
+  return `${FALLBACK_PREFIX}${owner}`;
+}
+
+function filterAdjacency(source: Map<string, Set<string>>, allowed: string[]): Map<string, Set<string>> {
+  const allowedSet = new Set(allowed);
+  const filtered = new Map<string, Set<string>>();
+  for (const id of allowed) {
+    const neighbors = source.get(id);
+    if (!neighbors) continue;
+    for (const neighbor of neighbors) {
+      if (!allowedSet.has(neighbor) || neighbor === id) continue;
+      if (!filtered.has(id)) filtered.set(id, new Set());
+      filtered.get(id)!.add(neighbor);
+    }
+  }
+  return filtered;
+}
+
+function assignFallbackShade(base: RgbaColor, assigned: Record<string, RgbaColor>): RgbaColor {
+  const used = new Set(Object.values(assigned).map(colorKey));
+  const baseHsl = rgbaToHsl(base);
+  let step = 0.05;
+  for (let i = 0; i < 10; i++) {
+    const candidate = hslToRgba({
+      h: baseHsl.h,
+      s: clamp(baseHsl.s + step, SAFE_SATURATION_MIN, SAFE_SATURATION_MAX),
+      l: clamp(baseHsl.l - step, SAFE_LIGHTNESS_MIN, SAFE_LIGHTNESS_MAX),
+      a: base.a,
+    });
+    const key = colorKey(candidate);
+    if (!used.has(key)) {
+      used.add(key);
+      return candidate;
+    }
+    step = -step * 1.15;
+  }
+  return cloneColor(base);
+}
+
+export function assignCantonShades(
+  nationId: string,
+  cantonIds: string[],
+  baseColor: RgbaColor,
+  options: { adjacency?: Map<string, Set<string>>; seed?: string | null } = {},
+): Record<string, RgbaColor> {
+  if (cantonIds.length === 0) {
+    return {};
+  }
+
+  const uniqueCantons = Array.from(new Set(cantonIds));
+  const adjacency = options.adjacency ?? new Map<string, Set<string>>();
+  const rng = createSeededRng(`${options.seed ?? 'default'}::${nationId}`);
+
+  const prioritized = uniqueCantons
+    .slice()
+    .sort((a, b) => (adjacency.get(b)?.size ?? 0) - (adjacency.get(a)?.size ?? 0) || a.localeCompare(b));
+
+  const order = shuffleWithRng(prioritized, rng);
+
+  const baseHsl = rgbaToHsl(baseColor);
+  const baseS = clamp(baseHsl.s, SAFE_SATURATION_MIN, SAFE_SATURATION_MAX);
+  const baseL = clamp(baseHsl.l, SAFE_LIGHTNESS_MIN, SAFE_LIGHTNESS_MAX);
+  const amplitudeL = Math.min(0.22, 0.12 + order.length * 0.015);
+  const amplitudeS = Math.min(0.18, 0.08 + order.length * 0.012);
+
+  const shades: Record<string, RgbaColor> = {};
+  const used = new Set<string>();
+
+  for (let i = 0; i < order.length; i++) {
+    const cantonId = order[i];
+    const direction = i % 2 === 0 ? 1 : -1;
+    const magnitude = Math.floor(i / 2) + 1;
+    const rangeFactor = Math.max(1, order.length);
+    let lightShift = direction * (amplitudeL * (magnitude / rangeFactor));
+    let satShift = direction * (amplitudeS * (magnitude / rangeFactor));
+    lightShift += (rng() - 0.5) * 0.04;
+    satShift += (rng() - 0.5) * 0.04;
+
+    if (order.length === 1 && Math.abs(lightShift) < 0.05) {
+      lightShift = 0.08;
+      satShift = 0.06;
+    }
+
+    let candidate = hslToRgba({
+      h: baseHsl.h,
+      s: clamp(baseS + satShift, SAFE_SATURATION_MIN, SAFE_SATURATION_MAX),
+      l: clamp(baseL + lightShift, SAFE_LIGHTNESS_MIN, SAFE_LIGHTNESS_MAX),
+      a: baseColor.a,
+    });
+
+    let key = colorKey(candidate);
+    let guard = 0;
+    while (used.has(key) && guard < 6) {
+      lightShift += (rng() - 0.5) * 0.06;
+      satShift += (rng() - 0.5) * 0.05;
+      candidate = hslToRgba({
+        h: baseHsl.h,
+        s: clamp(baseS + satShift, SAFE_SATURATION_MIN, SAFE_SATURATION_MAX),
+        l: clamp(baseL + lightShift, SAFE_LIGHTNESS_MIN, SAFE_LIGHTNESS_MAX),
+        a: baseColor.a,
+      });
+      key = colorKey(candidate);
+      guard++;
+    }
+
+    if (used.has(key)) {
+      candidate = enforceDistinctCandidate(baseColor, used);
+      key = colorKey(candidate);
+    } else {
+      used.add(key);
+    }
+
+    shades[cantonId] = candidate;
+  }
+
+  return shades;
+}
+
+export function computeCellColors(mode: MapViewMode, input: MapColoringInput): Array<RgbaColor | null> {
+  const result = new Array<RgbaColor | null>(Math.max(0, input.cellCount)).fill(null);
+
+  if (mode === 'nation') {
+    for (const [cellKey, owner] of Object.entries(input.cellOwnership)) {
+      const color = input.baseColors[owner];
+      if (!color) continue;
+      const cellId = Number(cellKey);
+      if (!Number.isFinite(cellId) || cellId < 0 || cellId >= result.length) continue;
+      result[cellId] = cloneColor(color);
+    }
+    return result;
+  }
+
+  const cellCantons = input.cellCantons ?? {};
+  const cantonAdjacency = input.cantonAdjacency ?? new Map<string, Set<string>>();
+  const assignments: Record<string, RgbaColor> = {};
+  const cantonCells = new Map<string, number[]>();
+  const cantonNation = new Map<string, string>();
+  const cantonsByNation = new Map<string, Set<string>>();
+
+  for (const [cellKey, owner] of Object.entries(input.cellOwnership)) {
+    if (!owner) continue;
+    const cantonId = resolveCantonId(cellKey, owner, cellCantons);
+    if (!cantonId) continue;
+    cantonNation.set(cantonId, owner);
+    let cells = cantonCells.get(cantonId);
+    if (!cells) {
+      cells = [];
+      cantonCells.set(cantonId, cells);
+    }
+    const numericId = Number(cellKey);
+    if (Number.isFinite(numericId) && numericId >= 0 && numericId < result.length) {
+      cells.push(numericId);
+    }
+    let set = cantonsByNation.get(owner);
+    if (!set) {
+      set = new Set();
+      cantonsByNation.set(owner, set);
+    }
+    set.add(cantonId);
+  }
+
+  for (const [nationId, cantonSet] of cantonsByNation.entries()) {
+    const base = input.baseColors[nationId];
+    if (!base) continue;
+    const cantonIds = Array.from(cantonSet);
+    if (cantonIds.length === 0) continue;
+    const filteredAdjacency = filterAdjacency(cantonAdjacency, cantonIds);
+    const shades = assignCantonShades(nationId, cantonIds, base, {
+      adjacency: filteredAdjacency,
+      seed: input.seed ?? undefined,
+    });
+    Object.assign(assignments, shades);
+  }
+
+  for (const [cantonId, cells] of cantonCells.entries()) {
+    const shade = assignments[cantonId];
+    if (!shade) {
+      const owner = cantonNation.get(cantonId);
+      if (!owner) continue;
+      const base = input.baseColors[owner];
+      if (!base) continue;
+      const fallback = assignFallbackShade(base, assignments);
+      assignments[cantonId] = fallback;
+      for (const cellId of cells) {
+        if (cellId >= 0 && cellId < result.length) {
+          result[cellId] = cloneColor(fallback);
+        }
+      }
+      continue;
+    }
+    for (const cellId of cells) {
+      if (cellId >= 0 && cellId < result.length) {
+        result[cellId] = cloneColor(shade);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function rgbaToCss(color: RgbaColor): string {
+  const r = clampByte(color.r);
+  const g = clampByte(color.g);
+  const b = clampByte(color.b);
+  const alpha = clamp(color.a, 0, 1);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function buildCantonAdjacency(
+  cellCantons: Record<string, string | undefined>,
+  cellOwnership: Record<string, string>,
+  cellOffsets: Uint32Array,
+  cellNeighbors: Int32Array,
+): Map<string, Set<string>> {
+  const adjacency = new Map<string, Set<string>>();
+  const totalCells = cellOffsets.length - 1;
+
+  for (let cellId = 0; cellId < totalCells; cellId++) {
+    const owner = cellOwnership[cellId] ?? cellOwnership[String(cellId)];
+    if (!owner) continue;
+    const cellKey = String(cellId);
+    const cantonId = resolveCantonId(cellKey, owner, cellCantons);
+    if (!cantonId) continue;
+
+    for (let ptr = cellOffsets[cellId]; ptr < cellOffsets[cellId + 1]; ptr++) {
+      const neighborId = cellNeighbors[ptr];
+      if (neighborId < 0 || neighborId >= totalCells) continue;
+      const neighborOwner = cellOwnership[neighborId] ?? cellOwnership[String(neighborId)];
+      if (neighborOwner !== owner) continue;
+      const neighborKey = String(neighborId);
+      const neighborCanton = resolveCantonId(neighborKey, neighborOwner, cellCantons);
+      if (!neighborCanton || neighborCanton === cantonId) continue;
+      if (!adjacency.has(cantonId)) adjacency.set(cantonId, new Set());
+      adjacency.get(cantonId)!.add(neighborCanton);
+      if (!adjacency.has(neighborCanton)) adjacency.set(neighborCanton, new Set());
+      adjacency.get(neighborCanton)!.add(cantonId);
+    }
+  }
+
+  return adjacency;
+}

--- a/client/src/mapViewControl.spec.ts
+++ b/client/src/mapViewControl.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initializeMapViewControl, resetMapViewControlForTests } from './mapViewControl';
+import { setMapViewMode, resetMapViewStateForTests } from './mapViewState';
+
+const runInVitest = typeof (globalThis as any).Bun === 'undefined';
+
+(runInVitest ? describe : describe.skip)('map view control', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="canvas-container" style="position: relative; width: 800px; height: 600px;"></div>
+      <div id="uiPanelRoot"></div>
+      <div id="debugSidebarRoot"></div>
+    `;
+    resetMapViewStateForTests();
+    resetMapViewControlForTests();
+  });
+
+  afterEach(() => {
+    resetMapViewControlForTests();
+    resetMapViewStateForTests();
+  });
+
+  it('mounts control directly on top of the canvas container', () => {
+    const container = document.getElementById('canvas-container') as HTMLDivElement;
+    const control = initializeMapViewControl(container);
+
+    expect(control.parentElement).toBe(container);
+    expect(control.id).toBe('mapViewControlRoot');
+    expect(control.style.position).toBe('absolute');
+
+    const uiPanel = document.getElementById('uiPanelRoot') as HTMLDivElement;
+    const debugRoot = document.getElementById('debugSidebarRoot') as HTMLDivElement;
+
+    expect(uiPanel.contains(control)).toBe(false);
+    expect(debugRoot.contains(control)).toBe(false);
+  });
+
+  it('updates the active state when switching modes', () => {
+    const container = document.getElementById('canvas-container') as HTMLDivElement;
+    const control = initializeMapViewControl(container);
+    const buttons = control.querySelectorAll<HTMLButtonElement>('button[data-mode]');
+
+    setMapViewMode('canton');
+
+    const cantonButton = Array.from(buttons).find((btn) => btn.dataset.mode === 'canton');
+    const nationButton = Array.from(buttons).find((btn) => btn.dataset.mode === 'nation');
+
+    expect(cantonButton?.getAttribute('aria-pressed')).toBe('true');
+    expect(nationButton?.getAttribute('aria-pressed')).toBe('false');
+  });
+});

--- a/client/src/mapViewControl.ts
+++ b/client/src/mapViewControl.ts
@@ -1,0 +1,119 @@
+import { getMapViewMode, onMapViewModeChange, setMapViewMode, MapViewMode } from './mapViewState';
+
+let controlRoot: HTMLDivElement | null = null;
+let unsubscribe: (() => void) | null = null;
+
+function applyButtonState(container: HTMLDivElement, mode: MapViewMode) {
+  const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button[data-mode]'));
+  for (const button of buttons) {
+    const targetMode = button.dataset.mode as MapViewMode | undefined;
+    const active = targetMode === mode;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+    button.style.background = active ? 'rgba(255, 255, 255, 0.18)' : 'transparent';
+    button.style.color = active ? '#ffffff' : '#d7d7d7';
+  }
+}
+
+function ensureContainerPosition(container: HTMLElement) {
+  const style = window.getComputedStyle(container);
+  if (style.position === 'static' || !style.position) {
+    container.style.position = 'relative';
+  }
+}
+
+function createToggleButton(label: string, mode: MapViewMode): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.dataset.mode = mode;
+  button.textContent = label;
+  button.style.cssText = `
+    border: none;
+    background: transparent;
+    color: inherit;
+    padding: 6px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 12px;
+    transition: background 0.2s ease;
+  `;
+  button.addEventListener('click', () => setMapViewMode(mode));
+  return button;
+}
+
+export function initializeMapViewControl(canvasContainer: HTMLElement): HTMLDivElement {
+  if (controlRoot) {
+    return controlRoot;
+  }
+
+  ensureContainerPosition(canvasContainer);
+
+  const root = document.createElement('div');
+  root.id = 'mapViewControlRoot';
+  root.style.cssText = `
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 4px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #f5f5f5;
+    border-radius: 999px;
+    padding: 6px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+    z-index: 1200;
+    pointer-events: auto;
+    font-family: 'Segoe UI', Arial, sans-serif;
+  `;
+  root.setAttribute('role', 'group');
+  root.setAttribute('aria-label', 'Map View Mode');
+
+  const nationButton = createToggleButton('Nation', 'nation');
+  const cantonButton = createToggleButton('Canton', 'canton');
+
+  root.appendChild(nationButton);
+  root.appendChild(cantonButton);
+
+  const updateButtons = (mode: MapViewMode) => {
+    applyButtonState(root, mode);
+  };
+
+  unsubscribe = onMapViewModeChange(updateButtons);
+  updateButtons(getMapViewMode());
+
+  root.addEventListener('pointerenter', () => {
+    root.style.background = 'rgba(0, 0, 0, 0.72)';
+  });
+  root.addEventListener('pointerleave', () => {
+    root.style.background = 'rgba(0, 0, 0, 0.6)';
+  });
+
+  const styleObserver = new MutationObserver(() => {
+    if (!canvasContainer.contains(root)) {
+      styleObserver.disconnect();
+      if (unsubscribe) {
+        unsubscribe();
+        unsubscribe = null;
+      }
+      controlRoot = null;
+    }
+  });
+  styleObserver.observe(canvasContainer, { childList: true });
+
+  canvasContainer.appendChild(root);
+  controlRoot = root;
+  return root;
+}
+
+export function resetMapViewControlForTests() {
+  if (controlRoot?.parentElement) {
+    controlRoot.parentElement.removeChild(controlRoot);
+  }
+  controlRoot = null;
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+}

--- a/client/src/mapViewState.ts
+++ b/client/src/mapViewState.ts
@@ -1,0 +1,30 @@
+export type MapViewMode = 'nation' | 'canton';
+
+type Listener = (mode: MapViewMode) => void;
+
+let currentMode: MapViewMode = 'nation';
+const listeners = new Set<Listener>();
+
+export function getMapViewMode(): MapViewMode {
+  return currentMode;
+}
+
+export function setMapViewMode(mode: MapViewMode): void {
+  if (mode === currentMode) return;
+  currentMode = mode;
+  for (const listener of Array.from(listeners)) {
+    listener(currentMode);
+  }
+}
+
+export function onMapViewModeChange(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetMapViewStateForTests(mode: MapViewMode = 'nation'): void {
+  currentMode = mode;
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary
- add a persistent map view state module and overlay control to switch between nation and canton views
- compute canton-aware shading palettes that respect adjacency and determinism while matching nation opacity
- render map overlays through the new color pipeline and add unit tests covering palette, determinism, and control placement

## Testing
- npm test --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68d9c9f998f88327bb8be30860622d46