### PR TITLE
Add canton view hull borders for nations and cantons

### DIFF
--- a/client/src/cantonBorders.spec.ts
+++ b/client/src/cantonBorders.spec.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeCantonViewBorders,
+  darkenColor,
+  lightenColor,
+  type BorderMeshData,
+} from './cantonBorders';
+import type { RgbaColor } from './mapColors';
+
+function createGridMesh(width: number, height: number, step = 10): BorderMeshData {
+  const columns = width + 1;
+  const rows = height + 1;
+  const vertices = new Float64Array(columns * rows * 2);
+  let index = 0;
+  for (let row = 0; row <= height; row++) {
+    for (let col = 0; col <= width; col++) {
+      vertices[index++] = col * step;
+      vertices[index++] = row * step;
+    }
+  }
+
+  const cellCount = width * height;
+  const cellOffsets = new Uint32Array(cellCount + 1);
+  const cellVertexIndices = new Uint32Array(cellCount * 4);
+  const cellNeighbors = new Int32Array(cellCount * 4).fill(-1);
+
+  let offset = 0;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const cellId = row * width + col;
+      cellOffsets[cellId] = offset;
+
+      const topLeft = row * columns + col;
+      const topRight = topLeft + 1;
+      const bottomLeft = (row + 1) * columns + col;
+      const bottomRight = bottomLeft + 1;
+
+      cellVertexIndices[offset] = topLeft;
+      cellVertexIndices[offset + 1] = topRight;
+      cellVertexIndices[offset + 2] = bottomRight;
+      cellVertexIndices[offset + 3] = bottomLeft;
+
+      cellNeighbors[offset] = row > 0 ? cellId - width : -1;
+      cellNeighbors[offset + 1] = col < width - 1 ? cellId + 1 : -1;
+      cellNeighbors[offset + 2] = row < height - 1 ? cellId + width : -1;
+      cellNeighbors[offset + 3] = col > 0 ? cellId - 1 : -1;
+
+      offset += 4;
+    }
+  }
+  cellOffsets[cellCount] = offset;
+
+  return {
+    allVertices: vertices,
+    cellOffsets,
+    cellVertexIndices,
+    cellNeighbors,
+    cellCount,
+  };
+}
+
+describe('computeCantonViewBorders', () => {
+  it('builds a single nation hull without interior per-cell edges', () => {
+    const mesh = createGridMesh(3, 3);
+    const cellOwnership: Record<string, string> = {};
+    for (let i = 0; i < mesh.cellCount; i++) {
+      cellOwnership[String(i)] = 'alpha';
+    }
+    const cellCantons: Record<string, string> = { '4': 'alpha-core' };
+
+    const borders = computeCantonViewBorders({ cellOwnership, cellCantons, mesh });
+    const alphaOutlines = borders.nationOutlines.filter((outline) => outline.nationId === 'alpha');
+    expect(alphaOutlines).toHaveLength(1);
+    const outline = alphaOutlines[0];
+    expect(outline.vertices[0]).toBe(outline.vertices[outline.vertices.length - 1]);
+    expect(outline.vertices).not.toContain(5);
+    const uniqueVertices = new Set(outline.vertices.slice(0, -1));
+    expect(uniqueVertices.size).toBeGreaterThan(3);
+  });
+
+  it('creates a single closed outline for a canton interface', () => {
+    const mesh = createGridMesh(3, 3);
+    const cellOwnership: Record<string, string> = {};
+    for (let i = 0; i < mesh.cellCount; i++) {
+      cellOwnership[String(i)] = 'alpha';
+    }
+    const cellCantons: Record<string, string> = {};
+    for (let i = 0; i < mesh.cellCount; i++) {
+      cellCantons[String(i)] = 'alpha-a';
+    }
+    cellCantons['4'] = 'alpha-b';
+
+    const borders = computeCantonViewBorders({ cellOwnership, cellCantons, mesh });
+    expect(borders.cantonOutlines).toHaveLength(1);
+    const outline = borders.cantonOutlines[0];
+    expect(outline.vertices[0]).toBe(outline.vertices[outline.vertices.length - 1]);
+    const uniqueVertices = new Set(outline.vertices.slice(0, -1));
+    expect(uniqueVertices).toEqual(new Set([5, 6, 10, 9]));
+  });
+
+  it('returns separate nation hulls for disconnected landmasses', () => {
+    const mesh = createGridMesh(2, 2);
+    const cellOwnership: Record<string, string> = {
+      '0': 'alpha',
+      '1': 'beta',
+      '2': 'beta',
+      '3': 'alpha',
+    };
+
+    const borders = computeCantonViewBorders({ cellOwnership, mesh });
+    const alphaOutlines = borders.nationOutlines.filter((outline) => outline.nationId === 'alpha');
+    expect(alphaOutlines).toHaveLength(2);
+    for (const outline of alphaOutlines) {
+      expect(outline.vertices[0]).toBe(outline.vertices[outline.vertices.length - 1]);
+      expect(new Set(outline.vertices.slice(0, -1)).size).toBe(4);
+    }
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const mesh = createGridMesh(3, 3);
+    const cellOwnership: Record<string, string> = {};
+    for (let i = 0; i < mesh.cellCount; i++) {
+      cellOwnership[String(i)] = i % 2 === 0 ? 'alpha' : 'beta';
+    }
+    const cellCantons: Record<string, string> = {
+      '0': 'alpha-a',
+      '2': 'beta-a',
+      '4': 'alpha-b',
+      '6': 'beta-b',
+    };
+
+    const first = computeCantonViewBorders({ cellOwnership, cellCantons, mesh });
+    const second = computeCantonViewBorders({ cellOwnership, cellCantons, mesh });
+    expect(first).toEqual(second);
+  });
+});
+
+describe('border styling helpers', () => {
+  it('darkens colors while preserving alpha', () => {
+    const base: RgbaColor = { r: 120, g: 150, b: 200, a: 0.4 };
+    const darker = darkenColor(base, 0.3);
+    expect(darker.r).toBeLessThan(base.r);
+    expect(darker.g).toBeLessThan(base.g);
+    expect(darker.b).toBeLessThan(base.b);
+    expect(darker.a).toBe(base.a);
+  });
+
+  it('lightens colors while preserving alpha', () => {
+    const base: RgbaColor = { r: 40, g: 80, b: 120, a: 0.4 };
+    const lighter = lightenColor(base, 0.25);
+    expect(lighter.r).toBeGreaterThan(base.r);
+    expect(lighter.g).toBeGreaterThan(base.g);
+    expect(lighter.b).toBeGreaterThan(base.b);
+    expect(lighter.a).toBe(base.a);
+  });
+});

--- a/client/src/cantonBorders.ts
+++ b/client/src/cantonBorders.ts
@@ -1,0 +1,275 @@
+import type { RgbaColor } from './mapColors';
+
+export interface BorderMeshData {
+  allVertices: Float64Array;
+  cellOffsets: Uint32Array;
+  cellVertexIndices: Uint32Array;
+  cellNeighbors: Int32Array;
+  cellCount: number;
+}
+
+export type OutlinePoint = [number, number];
+
+export interface OutlinePath {
+  nationId: string;
+  vertices: number[];
+  points: OutlinePoint[];
+}
+
+export interface CantonOutlinePath extends OutlinePath {
+  cantonIds: [string, string];
+}
+
+export interface CantonViewBorderInput {
+  cellOwnership: Record<string, string>;
+  cellCantons?: Record<string, string | undefined>;
+  mesh: BorderMeshData;
+}
+
+export interface CantonViewBorders {
+  nationOutlines: OutlinePath[];
+  cantonOutlines: CantonOutlinePath[];
+}
+
+interface Edge {
+  start: number;
+  end: number;
+}
+
+const FALLBACK_PREFIX = '__fallback__';
+
+function clampByte(value: number): number {
+  return Math.round(Math.max(0, Math.min(255, value)));
+}
+
+export function darkenColor(color: RgbaColor, amount: number): RgbaColor {
+  const factor = Math.max(0, Math.min(1, amount));
+  return {
+    r: clampByte(color.r * (1 - factor)),
+    g: clampByte(color.g * (1 - factor)),
+    b: clampByte(color.b * (1 - factor)),
+    a: color.a,
+  };
+}
+
+export function lightenColor(color: RgbaColor, amount: number): RgbaColor {
+  const factor = Math.max(0, Math.min(1, amount));
+  return {
+    r: clampByte(color.r + (255 - color.r) * factor),
+    g: clampByte(color.g + (255 - color.g) * factor),
+    b: clampByte(color.b + (255 - color.b) * factor),
+    a: color.a,
+  };
+}
+
+function lookupOwner(ownership: Record<string, string>, cellId: number): string | undefined {
+  return ownership[cellId] ?? ownership[String(cellId)];
+}
+
+function lookupCanton(
+  cellCantons: Record<string, string | undefined>,
+  cellId: number,
+  owner: string | undefined,
+): string | null {
+  const key = String(cellId);
+  const explicit = cellCantons[key];
+  if (explicit) return explicit;
+  if (!owner) return null;
+  return `${FALLBACK_PREFIX}${owner}`;
+}
+
+function addEdge(map: Map<string, Edge[]>, key: string, edge: Edge): void {
+  if (!map.has(key)) {
+    map.set(key, []);
+  }
+  map.get(key)!.push(edge);
+}
+
+function buildAdjacency(edges: Edge[]): Map<number, number[]> {
+  const adjacency = new Map<number, number[]>();
+  edges.forEach((edge, index) => {
+    if (!adjacency.has(edge.start)) adjacency.set(edge.start, []);
+    if (!adjacency.has(edge.end)) adjacency.set(edge.end, []);
+    adjacency.get(edge.start)!.push(index);
+    adjacency.get(edge.end)!.push(index);
+  });
+  for (const [vertex, indices] of adjacency.entries()) {
+    indices.sort((a, b) => {
+      const otherA = edges[a].start === vertex ? edges[a].end : edges[a].start;
+      const otherB = edges[b].start === vertex ? edges[b].end : edges[b].start;
+      if (otherA === otherB) return a - b;
+      return otherA - otherB;
+    });
+  }
+  return adjacency;
+}
+
+function buildClosedRings(edges: Edge[]): number[][] {
+  if (edges.length === 0) return [];
+  const adjacency = buildAdjacency(edges);
+  const visited = new Array(edges.length).fill(false);
+  const rings: number[][] = [];
+
+  for (let i = 0; i < edges.length; i++) {
+    if (visited[i]) continue;
+    const ring: number[] = [];
+    let edgeIndex = i;
+    let currentEdge = edges[edgeIndex];
+    visited[edgeIndex] = true;
+    ring.push(currentEdge.start);
+    ring.push(currentEdge.end);
+    let currentVertex = currentEdge.end;
+    let guard = 0;
+
+    while (currentVertex !== ring[0] && guard < edges.length * 2) {
+      guard++;
+      const candidates = adjacency.get(currentVertex);
+      if (!candidates) {
+        ring.length = 0;
+        break;
+      }
+      let nextEdgeIndex = -1;
+      for (const candidate of candidates) {
+        if (visited[candidate]) continue;
+        nextEdgeIndex = candidate;
+        break;
+      }
+      if (nextEdgeIndex === -1) {
+        ring.length = 0;
+        break;
+      }
+      visited[nextEdgeIndex] = true;
+      const nextEdge = edges[nextEdgeIndex];
+      const nextVertex = nextEdge.start === currentVertex ? nextEdge.end : nextEdge.start;
+      ring.push(nextVertex);
+      currentVertex = nextVertex;
+    }
+
+    if (ring.length >= 4 && currentVertex === ring[0]) {
+      rings.push(ring);
+    }
+  }
+
+  return rings;
+}
+
+function toPoints(vertices: Float64Array, ring: number[]): OutlinePoint[] {
+  const points: OutlinePoint[] = [];
+  for (const vertexIndex of ring) {
+    const x = vertices[vertexIndex * 2];
+    const y = vertices[vertexIndex * 2 + 1];
+    points.push([x, y]);
+  }
+  return points;
+}
+
+function minVertex(vertices: number[]): number {
+  if (vertices.length === 0) return Number.POSITIVE_INFINITY;
+  let min = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < vertices.length - 1; i++) {
+    if (vertices[i] < min) min = vertices[i];
+  }
+  return min;
+}
+
+function compareOutlinePaths(a: OutlinePath, b: OutlinePath): number {
+  if (a.nationId !== b.nationId) return a.nationId < b.nationId ? -1 : 1;
+  const aMin = minVertex(a.vertices);
+  const bMin = minVertex(b.vertices);
+  if (aMin !== bMin) return aMin - bMin;
+  if (a.vertices.length !== b.vertices.length) return a.vertices.length - b.vertices.length;
+  const aPoint = a.points[0];
+  const bPoint = b.points[0];
+  if (aPoint[0] !== bPoint[0]) return aPoint[0] - bPoint[0];
+  return aPoint[1] - bPoint[1];
+}
+
+export function computeCantonViewBorders(input: CantonViewBorderInput): CantonViewBorders {
+  const cellCantons = input.cellCantons ?? {};
+  const { mesh } = input;
+  const totalCells = mesh.cellCount;
+
+  const nationEdges = new Map<string, Edge[]>();
+  const cantonEdgeGroups = new Map<string, { nationId: string; cantons: [string, string]; edges: Edge[] }>();
+
+  for (let cellId = 0; cellId < totalCells; cellId++) {
+    const owner = lookupOwner(input.cellOwnership, cellId);
+    if (!owner) continue;
+
+    const start = mesh.cellOffsets[cellId];
+    const end = mesh.cellOffsets[cellId + 1];
+    if (start >= end) continue;
+
+    const cantonId = lookupCanton(cellCantons, cellId, owner);
+
+    for (let ptr = start; ptr < end; ptr++) {
+      const vertexA = mesh.cellVertexIndices[ptr];
+      const nextIndex = ptr + 1 < end ? ptr + 1 : start;
+      const vertexB = mesh.cellVertexIndices[nextIndex];
+      const neighborId = mesh.cellNeighbors[ptr];
+      const neighborOwner =
+        neighborId >= 0 && neighborId < totalCells
+          ? lookupOwner(input.cellOwnership, neighborId)
+          : undefined;
+
+      if (neighborId < 0 || neighborOwner !== owner) {
+        addEdge(nationEdges, owner, { start: vertexA, end: vertexB });
+        continue;
+      }
+
+      if (!cantonId) continue;
+      const neighborCanton = lookupCanton(cellCantons, neighborId, neighborOwner);
+      if (!neighborCanton || neighborCanton === cantonId) continue;
+      if (cellId > neighborId) continue;
+
+      const pair = cantonId < neighborCanton ? [cantonId, neighborCanton] : [neighborCanton, cantonId];
+      const key = `${owner}|${pair[0]}|${pair[1]}`;
+      if (!cantonEdgeGroups.has(key)) {
+        cantonEdgeGroups.set(key, { nationId: owner, cantons: pair as [string, string], edges: [] });
+      }
+      cantonEdgeGroups.get(key)!.edges.push({ start: vertexA, end: vertexB });
+    }
+  }
+
+  const nationOutlines: OutlinePath[] = [];
+  for (const [nationId, edges] of nationEdges.entries()) {
+    const rings = buildClosedRings(edges);
+    for (const ring of rings) {
+      nationOutlines.push({
+        nationId,
+        vertices: ring,
+        points: toPoints(mesh.allVertices, ring),
+      });
+    }
+  }
+
+  const cantonOutlines: CantonOutlinePath[] = [];
+  for (const group of cantonEdgeGroups.values()) {
+    const rings = buildClosedRings(group.edges);
+    for (const ring of rings) {
+      cantonOutlines.push({
+        nationId: group.nationId,
+        cantonIds: group.cantons,
+        vertices: ring,
+        points: toPoints(mesh.allVertices, ring),
+      });
+    }
+  }
+
+  nationOutlines.sort(compareOutlinePaths);
+  cantonOutlines.sort((a, b) => {
+    if (a.nationId !== b.nationId) return a.nationId < b.nationId ? -1 : 1;
+    if (a.cantonIds[0] !== b.cantonIds[0]) return a.cantonIds[0] < b.cantonIds[0] ? -1 : 1;
+    if (a.cantonIds[1] !== b.cantonIds[1]) return a.cantonIds[1] < b.cantonIds[1] ? -1 : 1;
+    const aMin = minVertex(a.vertices);
+    const bMin = minVertex(b.vertices);
+    if (aMin !== bMin) return aMin - bMin;
+    if (a.vertices.length !== b.vertices.length) return a.vertices.length - b.vertices.length;
+    const aPoint = a.points[0];
+    const bPoint = b.points[0];
+    if (aPoint[0] !== bPoint[0]) return aPoint[0] - bPoint[0];
+    return aPoint[1] - bPoint[1];
+  });
+
+  return { nationOutlines, cantonOutlines };
+}

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -16,7 +16,7 @@ import { updatePlannerSnapshot } from './planner';
 import { updateStatusBarFromGameState } from './statusBar';
 import { updateDebugSidebarFromGameState } from './debugSidebar';
 import { computeCellColors, buildCantonAdjacency, rgbaToCss, RgbaColor } from './mapColors';
-import { computeCantonViewBorders, lightenColor, darkenColor } from './cantonBorders';
+import { computeCantonViewBorders } from './cantonBorders';
 import { getMapViewMode } from './mapViewState';
 
 let canvas: HTMLCanvasElement;
@@ -452,10 +452,9 @@ function drawTerritoryOverlay(): void {
       const base = baseColors[outline.nationId];
       if (!base) continue;
       if (outline.points.length < 2) continue;
-      const strokeColor = lightenColor(base, 0.28);
-      const adjusted = { ...strokeColor, a: Math.min(1, base.a + 0.15) };
-      ctx.strokeStyle = rgbaToCss(adjusted);
-      ctx.lineWidth = 1.5;
+      const strokeColor = { ...base, a: Math.min(1, base.a + 0.15) };
+      ctx.strokeStyle = rgbaToCss(strokeColor);
+      ctx.lineWidth = 1.6;
       ctx.beginPath();
       ctx.moveTo(outline.points[0][0], outline.points[0][1]);
       for (let i = 1; i < outline.points.length; i++) {
@@ -472,10 +471,9 @@ function drawTerritoryOverlay(): void {
       const base = baseColors[outline.nationId];
       if (!base) continue;
       if (outline.points.length < 3) continue;
-      const strokeColor = darkenColor(base, 0.35);
-      const adjusted = { ...strokeColor, a: Math.min(1, base.a + 0.25) };
-      ctx.strokeStyle = rgbaToCss(adjusted);
-      ctx.lineWidth = 2.6;
+      const strokeColor = { ...base, a: Math.min(1, base.a + 0.3) };
+      ctx.strokeStyle = rgbaToCss(strokeColor);
+      ctx.lineWidth = 3.2;
       ctx.beginPath();
       ctx.moveTo(outline.points[0][0], outline.points[0][1]);
       for (let i = 1; i < outline.points.length; i++) {

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -451,7 +451,7 @@ function drawTerritoryOverlay(): void {
     for (const outline of borders.cantonOutlines) {
       const base = baseColors[outline.nationId];
       if (!base) continue;
-      if (outline.points.length < 3) continue;
+      if (outline.points.length < 2) continue;
       const strokeColor = lightenColor(base, 0.28);
       const adjusted = { ...strokeColor, a: Math.min(1, base.a + 0.15) };
       ctx.strokeStyle = rgbaToCss(adjusted);
@@ -462,7 +462,9 @@ function drawTerritoryOverlay(): void {
         const [x, y] = outline.points[i];
         ctx.lineTo(x, y);
       }
-      ctx.closePath();
+      if (outline.closed) {
+        ctx.closePath();
+      }
       ctx.stroke();
     }
 


### PR DESCRIPTION
## Summary
- add hull-based border computation for canton view and export color helpers
- render canton and nation outlines with layered styling in canton mode
- cover border generation and color helpers with deterministic tests

## Testing
- npm run test:client

------
https://chatgpt.com/codex/tasks/task_e_68d9e014bc9083278aafc0323845bef2