### PR TITLE
Add canton hover tooltips with capital indicator

### DIFF
--- a/client/src/cantonLabels.spec.ts
+++ b/client/src/cantonLabels.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { CANTON_FALLBACK_PREFIX } from './mapColors';
 import { deriveCantonLabel } from './cantonLabels';
 
 describe('deriveCantonLabel', () => {
@@ -54,6 +55,42 @@ describe('deriveCantonLabel', () => {
       label: 'Stormfall Republic Canton 3/3',
       index: 3,
       total: 3,
+      isCapital: false,
+    });
+  });
+
+  it('ignores fallback canton IDs and leaves real totals unchanged', () => {
+    const cantonOrder = ['c1', 'c2'];
+    const fallbackId = `${CANTON_FALLBACK_PREFIX}alpha`;
+
+    const fallbackResult = deriveCantonLabel({
+      nationId: 'alpha',
+      nationName: 'Coastwatch Alliance',
+      cantonId: fallbackId,
+      cantonOrder,
+      cantonMeta: {
+        c1: { capital: true },
+        c2: { capital: false },
+      },
+    });
+
+    expect(fallbackResult).toBeNull();
+
+    const realResult = deriveCantonLabel({
+      nationId: 'alpha',
+      nationName: 'Coastwatch Alliance',
+      cantonId: 'c2',
+      cantonOrder,
+      cantonMeta: {
+        c1: { capital: true },
+        c2: { capital: false },
+      },
+    });
+
+    expect(realResult).toEqual({
+      label: 'Coastwatch Alliance Canton 2/2',
+      index: 2,
+      total: 2,
       isCapital: false,
     });
   });

--- a/client/src/cantonLabels.spec.ts
+++ b/client/src/cantonLabels.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { deriveCantonLabel } from './cantonLabels';
+
+describe('deriveCantonLabel', () => {
+  it('marks capital cantons with a crown when meta indicates capital', () => {
+    const result = deriveCantonLabel({
+      nationId: 'alpha',
+      nationName: 'Aurora Dominion',
+      cantonId: 'c1',
+      cantonOrder: ['c1', 'c2'],
+      cantonMeta: {
+        c1: { capital: true },
+        c2: { capital: false },
+      },
+    });
+
+    expect(result).toEqual({
+      label: '👑 Aurora Dominion Canton 1/2',
+      index: 1,
+      total: 2,
+      isCapital: true,
+    });
+  });
+
+  it('falls back to order-based capital when meta is missing', () => {
+    const result = deriveCantonLabel({
+      nationId: 'beta',
+      nationName: 'Silverhaven',
+      cantonId: 'c2',
+      cantonOrder: ['c1', 'c2', 'c3'],
+    });
+
+    expect(result).toEqual({
+      label: 'Silverhaven Canton 2/3',
+      index: 2,
+      total: 3,
+      isCapital: false,
+    });
+  });
+
+  it('adds missing cantons deterministically', () => {
+    const result = deriveCantonLabel({
+      nationId: 'gamma',
+      nationName: 'Stormfall Republic',
+      cantonId: 'c4',
+      cantonOrder: ['c2', 'c3'],
+      cantonMeta: {
+        c2: { capital: true },
+        c4: { capital: false },
+      },
+    });
+
+    expect(result).toEqual({
+      label: 'Stormfall Republic Canton 3/3',
+      index: 3,
+      total: 3,
+      isCapital: false,
+    });
+  });
+
+  it('falls back to nation id when name is empty', () => {
+    const result = deriveCantonLabel({
+      nationId: 'delta',
+      nationName: '   ',
+      cantonId: 'c1',
+      cantonOrder: ['c1'],
+      cantonMeta: { c1: { capital: true } },
+    });
+
+    expect(result).toEqual({
+      label: '👑 delta Canton 1/1',
+      index: 1,
+      total: 1,
+      isCapital: true,
+    });
+  });
+});

--- a/client/src/cantonLabels.ts
+++ b/client/src/cantonLabels.ts
@@ -1,3 +1,5 @@
+import { CANTON_FALLBACK_PREFIX } from './mapColors';
+
 export interface CantonMetaLike {
   capital?: boolean;
 }
@@ -38,6 +40,10 @@ function sortCantons(
 
 export function deriveCantonLabel(context: CantonLabelContext): CantonLabelResult | null {
   if (!context.nationId || !context.cantonId) {
+    return null;
+  }
+
+  if (context.cantonId.startsWith(CANTON_FALLBACK_PREFIX)) {
     return null;
   }
 

--- a/client/src/cantonLabels.ts
+++ b/client/src/cantonLabels.ts
@@ -1,0 +1,75 @@
+export interface CantonMetaLike {
+  capital?: boolean;
+}
+
+export interface CantonLabelContext {
+  nationId: string;
+  nationName?: string;
+  cantonId: string;
+  cantonOrder: string[];
+  cantonMeta?: Record<string, CantonMetaLike | undefined>;
+}
+
+export interface CantonLabelResult {
+  label: string;
+  index: number;
+  total: number;
+  isCapital: boolean;
+}
+
+function normalizeNationName(nationId: string, nationName?: string): string {
+  const trimmed = nationName?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : nationId;
+}
+
+function sortCantons(
+  cantonIds: string[],
+  cantonMeta: Record<string, CantonMetaLike | undefined> | undefined,
+): string[] {
+  return cantonIds.slice().sort((a, b) => {
+    const aCapital = cantonMeta?.[a]?.capital ?? false;
+    const bCapital = cantonMeta?.[b]?.capital ?? false;
+    if (aCapital !== bCapital) {
+      return aCapital ? -1 : 1;
+    }
+    return a.localeCompare(b);
+  });
+}
+
+export function deriveCantonLabel(context: CantonLabelContext): CantonLabelResult | null {
+  if (!context.nationId || !context.cantonId) {
+    return null;
+  }
+
+  const order = Array.isArray(context.cantonOrder)
+    ? context.cantonOrder.slice()
+    : [];
+
+  if (!order.includes(context.cantonId)) {
+    order.push(context.cantonId);
+    const sorted = sortCantons(order, context.cantonMeta);
+    order.length = 0;
+    order.push(...sorted);
+  }
+
+  const total = order.length;
+  if (total === 0) {
+    return null;
+  }
+
+  const index = order.indexOf(context.cantonId);
+  if (index === -1) {
+    return null;
+  }
+
+  const isCapital = context.cantonMeta?.[context.cantonId]?.capital ?? index === 0;
+  const nationName = normalizeNationName(context.nationId, context.nationName);
+  const label = `${isCapital ? '👑 ' : ''}${nationName} Canton ${index + 1}/${total}`;
+
+  return {
+    label,
+    index: index + 1,
+    total,
+    isCapital,
+  };
+}

--- a/client/src/mapColors.ts
+++ b/client/src/mapColors.ts
@@ -45,7 +45,7 @@ export const CANTON_CONTRAST_CONFIG = {
   minBackgroundLightness: 0.18,
   backgroundColor: BACKGROUND_COLOR,
 } as const;
-const FALLBACK_PREFIX = '__fallback__';
+export const CANTON_FALLBACK_PREFIX = '__fallback__';
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -221,7 +221,7 @@ function shuffleWithRng<T>(items: T[], rng: () => number): T[] {
   return copy;
 }
 
-function resolveCantonId(
+export function resolveCantonId(
   cellKey: string,
   owner: string | undefined,
   cellCantons: Record<string, string | undefined>,
@@ -229,7 +229,7 @@ function resolveCantonId(
   const explicit = cellCantons[cellKey];
   if (explicit) return explicit;
   if (!owner) return null;
-  return `${FALLBACK_PREFIX}${owner}`;
+  return `${CANTON_FALLBACK_PREFIX}${owner}`;
 }
 
 function filterAdjacency(source: Map<string, Set<string>>, allowed: string[]): Map<string, Set<string>> {


### PR DESCRIPTION
## Summary
- add a hover tooltip for cantons that shows local numbering and a crown for the capital canton
- track nation names and canton metadata updates so tooltip content reflects repartitions deterministically
- extract reusable canton label formatter with dedicated unit tests and export the shared canton resolver

## Testing
- npm test --prefix client

------
https://chatgpt.com/codex/tasks/task_e_68d9ea9db44c8327bd48b16e6bc95170